### PR TITLE
Add -set-exit-status flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Flags:
   -min          	   minimum value, only works with -numbers
   -max          	   maximum value, only works with -numbers
   -output            output formatting (text or json)
-  -set_exit_status   Set exit status to 2 if any issues are found
+  -set-exit-status   Set exit status to 2 if any issues are found
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Flags:
   -min          	   minimum value, only works with -numbers
   -max          	   maximum value, only works with -numbers
   -output            output formatting (text or json)
+  -set_exit_status   Set exit status to 2 if any issues are found
 
 Examples:
 

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -65,6 +65,8 @@ func main() {
 		usage(os.Stderr)
 		os.Exit(1)
 	}
+
+	lintFailed := false
 	for _, path := range args {
 		anyIssues, err := run(path)
 		if err != nil {
@@ -72,9 +74,13 @@ func main() {
 			os.Exit(1)
 		}
 
-		if anyIssues && *flagSetExitStatus {
-			os.Exit(2)
+		if anyIssues {
+			lintFailed = true
 		}
+	}
+
+	if lintFailed && *flagSetExitStatus {
+		os.Exit(2)
 	}
 }
 

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -30,7 +30,7 @@ Flags:
   -min               minimum value, only works with -numbers
   -max               maximum value, only works with -numbers
   -output            output formatting (text or json)
-  -set_exit_status   Set exit status to 2 if any issues are found
+  -set-exit-status   Set exit status to 2 if any issues are found
 
 Examples:
 
@@ -50,7 +50,7 @@ var (
 	flagMin            = flag.Int("min", 0, "minimum value, only works with -numbers")
 	flagMax            = flag.Int("max", 0, "maximum value, only works with -numbers")
 	flagOutput         = flag.String("output", "text", "output formatting")
-	flagSetExitStatus  = flag.Bool("set_exit_status", false, "Set exit status to 2 if any issues are found")
+	flagSetExitStatus  = flag.Bool("set-exit-status", false, "Set exit status to 2 if any issues are found")
 )
 
 func main() {


### PR DESCRIPTION
Closes #9. This adds a new flag to *goconst* that can be used to make it exit with a non-zero exit code if any issues are found.

In short, I implemented this by having `run`/`printOutput` return an additional boolean value to indicate if any issues were found in the analysed code. If `true` (and `-set_exit_status` is used), *goconst* will now exit with a status code of `2`. I chose `2` because *goconst* will already exit with the status code `1` if an error occurs.

These changes should be completely backwards compatible. From manual testing I can say that this works as expected.