### PR TITLE
Adding missing ProcessResults() call

### DIFF
--- a/api.go
+++ b/api.go
@@ -42,6 +42,7 @@ func Run(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
 			p:           p,
 		}, f)
 	}
+	p.ProcessResults()
 
 	for str, item := range p.strs {
 		fi := item[0]


### PR DESCRIPTION
I think that `ProcessResults()` call is missing - configuration setting regarding minimal number of occurrences are being ignored.