### PR TITLE
Telling types of violations one from another

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,6 +19,7 @@ type Config struct {
 	ParseNumbers       bool
 	NumberMin          int
 	NumberMax          int
+	ExcludeTypes       map[Type]bool
 }
 
 func Run(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
@@ -32,6 +33,7 @@ func Run(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
 		cfg.NumberMax,
 		cfg.MinStringLength,
 		cfg.MinOccurrences,
+		cfg.ExcludeTypes,
 	)
 	var issues []Issue
 	for _, f := range files {

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -94,6 +94,7 @@ func run(path string) (bool, error) {
 		*flagMax,
 		*flagMinLength,
 		*flagMinOccurrences,
+		map[goconst.Type]bool{},
 	)
 	strs, consts, err := gco.ParseTree()
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -28,6 +28,7 @@ type Parser struct {
 	ignoreTests, matchConstant bool
 	minLength, minOccurrences  int
 	numberMin, numberMax       int
+	excludeTypes               map[Type]bool
 
 	supportedTokens []token.Token
 
@@ -38,7 +39,7 @@ type Parser struct {
 
 // New creates a new instance of the parser.
 // This is your entry point if you'd like to use goconst as an API.
-func New(path, ignore string, ignoreTests, matchConstant, numbers bool, numberMin, numberMax, minLength, minOccurrences int) *Parser {
+func New(path, ignore string, ignoreTests, matchConstant, numbers bool, numberMin, numberMax, minLength, minOccurrences int, excludeTypes map[Type]bool) *Parser {
 	supportedTokens := []token.Token{token.STRING}
 	if numbers {
 		supportedTokens = append(supportedTokens, token.INT, token.FLOAT)
@@ -54,6 +55,7 @@ func New(path, ignore string, ignoreTests, matchConstant, numbers bool, numberMi
 		numberMin:       numberMin,
 		numberMax:       numberMax,
 		supportedTokens: supportedTokens,
+		excludeTypes:    excludeTypes,
 
 		// Initialize the maps
 		strs:   Strings{},
@@ -162,3 +164,13 @@ type ExtendedPos struct {
 	token.Position
 	packageName string
 }
+
+type Type int
+
+const (
+	Assignment Type = iota
+	Binary
+	Case
+	Return
+	Call
+)


### PR DESCRIPTION
Background information is available in https://github.com/golangci/golangci-lint/pull/1500.

What I'm trying to achieve here is to have:
* violation types being distinguishable one from another
* ~types being passed back to program calling `goconst.Run()`~

It useful for us in `golangci-lint` to start using upstream version of `goconst` instead of outdated fork that we have been relying on for a while.

Fixes #11.