### PR TITLE
Actually use IgnoreTests from the API.

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package goconst
 import (
 	"go/ast"
 	"go/token"
+	"strings"
 )
 
 type Issue struct {
@@ -38,6 +39,11 @@ func Run(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
 	)
 	var issues []Issue
 	for _, f := range files {
+		if p.ignoreTests {
+			if filename := fset.Position(f.Pos()).Filename; strings.HasSuffix(filename, testSuffix) {
+				continue
+			}
+		}
 		ast.Walk(&treeVisitor{
 			fileSet:     fset,
 			packageName: "",


### PR DESCRIPTION
Because the API took a list of `*File`s, it didn't actually skip tests
as ParseTree did. This checks the name of each file before visiting its
AST.