### PR TITLE
Revert "fix bug about not support more operations on string (#21)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.idea
-goconst

--- a/tests/main.go
+++ b/tests/main.go
@@ -27,12 +27,7 @@ func testCase() string {
 	case "moo":
 		return ""
 	}
-
-	test2 := "moo" + fmt.Sprintf("%d", testInt())
-	if test2 > "foo" {
-		test2 += "foo"
-	}
-	return "foo" + test2
+	return "foo"
 }
 
 func testInt() int {

--- a/visitor.go
+++ b/visitor.go
@@ -62,6 +62,10 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 
 	// if foo == "moo"
 	case *ast.BinaryExpr:
+		if t.Op != token.EQL && t.Op != token.NEQ {
+			return v
+		}
+
 		var lit *ast.BasicLit
 		var ok bool
 


### PR DESCRIPTION
PR #21 introduced a breaking change without an option to disable it. This revert intends to be a quicker way to get the old (working) behaviour, as I am not familiar with the project 😅     
  
Fixes https://github.com/jgautheron/goconst/issues/25
   
More info on https://github.com/golangci/golangci-lint/issues/4240