### PR TITLE
Add support for finding constants with duplicated values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Flags:
   -min-occurrences   report from how many occurrences (default: 2)
   -min-length        only report strings with the minimum given length (default: 3)
   -match-constant    look for existing constants matching the values
+  -find-duplicates   look for constants with identical values
   -numbers           search also for duplicated numbers
   -min          	   minimum value, only works with -numbers
   -max          	   maximum value, only works with -numbers

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -81,6 +81,7 @@ func BenchmarkParseTree(b *testing.B) {
 				false, // ignoreTests
 				false, // matchConstant
 				false, // numbers
+				true,  // findDuplicates
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength
@@ -104,6 +105,7 @@ func BenchmarkParseTree(b *testing.B) {
 				false, // ignoreTests
 				false, // matchConstant
 				true,  // numbers
+				true,  // findDuplicates
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength
@@ -127,6 +129,7 @@ func BenchmarkParseTree(b *testing.B) {
 				false, // ignoreTests
 				true,  // matchConstant
 				false, // numbers
+				true,  // findDuplicates
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength
@@ -156,6 +159,7 @@ func BenchmarkParallelProcessing(b *testing.B) {
 					"",
 					false,
 					false,
+					true,
 					true,
 					0,
 					0,
@@ -304,6 +308,7 @@ func helperFunction%d() string {
 				false,
 				false,
 				true,
+				true,
 				0,
 				0,
 				3,
@@ -331,6 +336,7 @@ func helperFunction%d() string {
 				"",
 				false,
 				false,
+				true,
 				true,
 				0,
 				0,
@@ -377,7 +383,7 @@ func BenchmarkFileReadingPerformance(b *testing.B) {
 
 		// Benchmark the optimized file reading
 		b.Run(fmt.Sprintf("OptimizedIO_%d", size), func(b *testing.B) {
-			parser := New("", "", "", false, false, false, 0, 0, 3, 2, make(map[Type]bool))
+			parser := New("", "", "", false, false, false, true, 0, 0, 3, 2, make(map[Type]bool))
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {

--- a/integration_test.go
+++ b/integration_test.go
@@ -14,6 +14,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 		numberMin       int
 		numberMax       int
 		minLength       int
+		findDuplicates  bool
 		minOccurrences  int
 		expectedStrings int
 	}{
@@ -80,6 +81,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 				tt.ignoreTests,
 				tt.matchConstant,
 				tt.numbers,
+				tt.findDuplicates,
 				tt.numberMin,
 				tt.numberMax,
 				tt.minLength,
@@ -140,6 +142,7 @@ func TestIntegrationExcludeTypes(t *testing.T) {
 				false, // ignoreTests
 				false, // matchConstant
 				false, // numbers
+				false, // findDuplicates
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength

--- a/parser.go
+++ b/parser.go
@@ -133,6 +133,7 @@ type Parser struct {
 	// Meant to be passed via New()
 	path, ignore, ignoreStrings string
 	ignoreTests, matchConstant  bool
+	findDuplicates              bool
 	minLength, minOccurrences   int
 	numberMin, numberMax        int
 	excludeTypes                map[Type]bool
@@ -175,11 +176,12 @@ type Parser struct {
 //   - ignoreTests: whether to ignore test files
 //   - matchConstant: whether to match strings with existing constants
 //   - numbers: whether to analyze number literals
+//   - findDuplicates: whether to find consts with duplicate values
 //   - numberMin/numberMax: range limits for number analysis
 //   - minLength: minimum string length to consider
 //   - minOccurrences: minimum occurrences to report
 //   - excludeTypes: map of context types to exclude
-func New(path, ignore, ignoreStrings string, ignoreTests, matchConstant, numbers bool, numberMin, numberMax, minLength, minOccurrences int, excludeTypes map[Type]bool) *Parser {
+func New(path, ignore, ignoreStrings string, ignoreTests, matchConstant, numbers, findDuplicates bool, numberMin, numberMax, minLength, minOccurrences int, excludeTypes map[Type]bool) *Parser {
 	supportedTokens := []token.Token{token.STRING}
 	if numbers {
 		supportedTokens = append(supportedTokens, token.INT, token.FLOAT)
@@ -228,6 +230,7 @@ func New(path, ignore, ignoreStrings string, ignoreTests, matchConstant, numbers
 		ignore:             ignore,
 		ignoreStrings:      ignoreStrings,
 		ignoreTests:        ignoreTests,
+		findDuplicates:     findDuplicates,
 		matchConstant:      matchConstant,
 		minLength:          minLength,
 		minOccurrences:     minOccurrences,
@@ -743,7 +746,7 @@ func (p *Parser) ProcessResults() {
 type Strings map[string][]ExtendedPos
 
 // Constants maps string values to their constant definitions.
-type Constants map[string]ConstType
+type Constants map[string][]ConstType
 
 // ConstType holds information about a constant declaration.
 type ConstType struct {

--- a/parser_test.go
+++ b/parser_test.go
@@ -137,6 +137,7 @@ func TestParser_New(t *testing.T) {
 		true, // ignoreTests
 		true, // matchConstant
 		true, // numbers
+		true, //findDuplicates
 		100,  // numberMin
 		500,  // numberMax
 		3,    // minLength
@@ -159,6 +160,9 @@ func TestParser_New(t *testing.T) {
 	}
 	if !p.matchConstant {
 		t.Errorf("New() matchConstant = %v, want %v", p.matchConstant, true)
+	}
+	if !p.findDuplicates {
+		t.Errorf("New() findDuplicates %v, want %v", p.findDuplicates, true)
 	}
 	if p.minLength != 3 {
 		t.Errorf("New() minLength = %v, want %v", p.minLength, 3)
@@ -271,8 +275,9 @@ func test() {
 				tt.ignoreTests,
 				tt.matchConstant,
 				tt.numbers,
-				0, // numberMin
-				0, // numberMax
+				false, // TODO: test
+				0,     // numberMin
+				0,     // numberMax
 				tt.minLength,
 				tt.minOccurrences,
 				map[Type]bool{},
@@ -316,6 +321,7 @@ func nested() {
 			false,         // ignoreTests
 			false,         // matchConstant
 			false,         // numbers
+			false,         // findDuplicates
 			0,             // numberMin
 			0,             // numberMax
 			3,             // minLength
@@ -354,6 +360,7 @@ func TestFunction(t *testing.T) {
 		ignoreTests     bool
 		matchConstant   bool
 		numbers         bool
+		findDuplicates  bool
 		minLength       int
 		minOccurrences  int
 		expectedStrings int
@@ -364,6 +371,7 @@ func TestFunction(t *testing.T) {
 			ignoreTests:     false,
 			matchConstant:   false,
 			numbers:         false,
+			findDuplicates:  false,
 			minLength:       3,
 			minOccurrences:  2,
 			expectedStrings: 2, // Should find both "repeated" and "test_repeated"
@@ -374,6 +382,7 @@ func TestFunction(t *testing.T) {
 			ignoreTests:     true,
 			matchConstant:   false,
 			numbers:         false,
+			findDuplicates:  false,
 			minLength:       3,
 			minOccurrences:  2,
 			expectedStrings: 1, // Should only find "repeated"
@@ -389,6 +398,7 @@ func TestFunction(t *testing.T) {
 				tt.ignoreTests,
 				tt.matchConstant,
 				tt.numbers,
+				tt.findDuplicates,
 				0, // numberMin
 				0, // numberMax
 				tt.minLength,
@@ -429,6 +439,7 @@ func ignored() {
 			false,       // ignoreTests
 			false,       // matchConstant
 			false,       // numbers
+			false,       // findDuplicates
 			0,           // numberMin
 			0,           // numberMax
 			3,           // minLength
@@ -476,6 +487,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 				false,
 				false,
 				true,
+				false, // findDuplicates
 				0,
 				0,
 				3,
@@ -500,6 +512,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 				false,
 				false,
 				true,
+				false,
 				0,
 				0,
 				3,
@@ -527,6 +540,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 				false,
 				false,
 				true,
+				false,
 				0,
 				0,
 				3,
@@ -556,6 +570,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 					false,
 					false,
 					true,
+					false,
 					0,
 					0,
 					3,
@@ -706,7 +721,7 @@ func BenchmarkFileReading(b *testing.B) {
 	// Test optimized file reading with different file sizes
 	for i, size := range testSizes {
 		b.Run(fmt.Sprintf("OptimizedIO_%d", size), func(b *testing.B) {
-			p := New("", "", "", false, false, false, 0, 0, 3, 2, map[Type]bool{})
+			p := New("", "", "", false, false, false, false, 0, 0, 3, 2, map[Type]bool{})
 
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {

--- a/testdata/sample.go
+++ b/testdata/sample.go
@@ -67,3 +67,8 @@ func testContexts() {
 
 	fmt.Println(assigned)
 }
+
+func testDuplicateConsts() {
+	// This const should be detected as a duplicate const of MatchingConst
+	const duplicate = "should be constant"
+}


### PR DESCRIPTION
Adds a flag for finding and reporting on duplicate constants, along with tests.
Also adds backwards-compatible fields to the `Issue` API for eventual use in golangci-lint.

I went ahead and set this new flag in the benchmarks, since it will result in additional allocations when set. 

I'm open to making any changes requested by maintainers. Just let me know.

There are a few extensions I can imagine, but not all of them are quite as easy to implement.
- Limiting search within the same file, within the same package, or across packages. Currently this feature searches only across packages.
- Ignoring unexported constants when checking for duplicates.
- Adding support for constant expressions.

Closes #29.