### PR TITLE
Compute and use constant expressions via the type checker.

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package goconst
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"sort"
 	"strings"
 	"sync"
@@ -114,7 +115,7 @@ func NewWithIgnorePatterns(
 
 // RunWithConfig is a convenience function that runs the analysis with a Config object
 // directly supporting multiple ignore patterns.
-func RunWithConfig(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
+func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info, cfg *Config) ([]Issue, error) {
 	p := NewWithIgnorePatterns(
 		"",
 		"",
@@ -180,9 +181,9 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue
 			ast.Walk(&treeVisitor{
 				fileSet:     fset,
 				packageName: emptyStr,
-				fileName:    emptyStr,
 				p:           p,
 				ignoreRegex: p.ignoreStringsRegex,
+				typeInfo:    typeInfo,
 			}, f)
 		}(f)
 	}
@@ -281,6 +282,6 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue
 // Run analyzes the provided AST files for duplicated strings or numbers
 // according to the provided configuration.
 // It returns a slice of Issue objects containing the findings.
-func Run(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
-	return RunWithConfig(files, fset, cfg)
+func Run(files []*ast.File, fset *token.FileSet, typeInfo *types.Info, cfg *Config) ([]Issue, error) {
+	return RunWithConfig(files, fset, typeInfo, cfg)
 }

--- a/api.go
+++ b/api.go
@@ -64,8 +64,10 @@ type Config struct {
 	NumberMax int
 	// ExcludeTypes allows excluding specific types of contexts
 	ExcludeTypes map[Type]bool
-	// FindDuplicated constants enables finding constants whose values match existing constants in other packages.
+	// FindDuplicates enables finding constants whose values match existing constants in other packages.
 	FindDuplicates bool
+	// EvalConstExpressions enables evaluation of constant expressions like Prefix + "suffix"
+	EvalConstExpressions bool
 }
 
 // NewWithIgnorePatterns creates a new instance of the parser with support for multiple ignore patterns.
@@ -73,7 +75,7 @@ type Config struct {
 func NewWithIgnorePatterns(
 	path, ignore string,
 	ignoreStrings []string,
-	ignoreTests, matchConstant, numbers, findDuplicates bool,
+	ignoreTests, matchConstant, numbers, findDuplicates, evalConstExpressions bool,
 	numberMin, numberMax, minLength, minOccurrences int,
 	excludeTypes map[Type]bool) *Parser {
 
@@ -101,6 +103,7 @@ func NewWithIgnorePatterns(
 		matchConstant,
 		numbers,
 		findDuplicates,
+		evalConstExpressions,
 		numberMin,
 		numberMax,
 		minLength,
@@ -120,6 +123,7 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue
 		cfg.MatchWithConstants,
 		cfg.ParseNumbers,
 		cfg.FindDuplicates,
+		cfg.EvalConstExpressions,
 		cfg.NumberMin,
 		cfg.NumberMax,
 		cfg.MinStringLength,

--- a/api_test.go
+++ b/api_test.go
@@ -63,7 +63,8 @@ func example() {
 	const ConstB = ConstA + "st"
 }`,
 			config: &Config{
-				FindDuplicates: true,
+				FindDuplicates:       true,
+				EvalConstExpressions: true,
 			},
 			expectedIssues: 1,
 		},

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -31,6 +31,7 @@ func BenchmarkParseSampleFile(b *testing.B) {
 			strs:             Strings{},
 			consts:           Constants{},
 			matchConstant:    true,
+			evalConstExpressions: false, // Disable for benchmark
 			stringCount:      make(map[string]int),
 			stringMutex:      sync.RWMutex{},
 			stringCountMutex: sync.RWMutex{},
@@ -60,6 +61,7 @@ func BenchmarkRun(b *testing.B) {
 		MinStringLength:    3,
 		MinOccurrences:     2,
 		MatchWithConstants: true,
+		EvalConstExpressions: false, // Disable for benchmark
 	}
 
 	b.ResetTimer()
@@ -82,6 +84,7 @@ func BenchmarkParseTree(b *testing.B) {
 				false, // matchConstant
 				false, // numbers
 				true,  // findDuplicates
+				false, // evalConstExpressions
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength
@@ -106,6 +109,7 @@ func BenchmarkParseTree(b *testing.B) {
 				false, // matchConstant
 				true,  // numbers
 				true,  // findDuplicates
+				false, // evalConstExpressions
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength
@@ -130,6 +134,7 @@ func BenchmarkParseTree(b *testing.B) {
 				true,  // matchConstant
 				false, // numbers
 				true,  // findDuplicates
+				false, // evalConstExpressions
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength
@@ -145,8 +150,8 @@ func BenchmarkParseTree(b *testing.B) {
 	})
 }
 
-// BenchmarkParallelProcessing tests the parallel implementation with various concurrency levels.
-func BenchmarkParallelProcessing(b *testing.B) {
+// BenchmarkParallelProcessing2 tests the parallel implementation with various concurrency levels.
+func BenchmarkParallelProcessing2(b *testing.B) {
 	// Test with different concurrency levels
 	concurrencyLevels := []int{1, 2, 4, 8, runtime.NumCPU()}
 
@@ -161,6 +166,7 @@ func BenchmarkParallelProcessing(b *testing.B) {
 					false,
 					true,
 					true,
+					false, // evalConstExpressions
 					0,
 					0,
 					3,
@@ -309,6 +315,7 @@ func helperFunction%d() string {
 				false,
 				true,
 				true,
+				false, // evalConstExpressions
 				0,
 				0,
 				3,
@@ -338,6 +345,7 @@ func helperFunction%d() string {
 				false,
 				true,
 				true,
+				false, // evalConstExpressions
 				0,
 				0,
 				3,
@@ -383,7 +391,7 @@ func BenchmarkFileReadingPerformance(b *testing.B) {
 
 		// Benchmark the optimized file reading
 		b.Run(fmt.Sprintf("OptimizedIO_%d", size), func(b *testing.B) {
-			parser := New("", "", "", false, false, false, true, 0, 0, 3, 2, make(map[Type]bool))
+			parser := New("", "", "", false, false, false, true, false, 0, 0, 3, 2, make(map[Type]bool))
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -427,4 +435,251 @@ func generateRandomContent(size int) []byte {
 	}
 
 	return content
+}
+
+func BenchmarkParseTreeMinimal(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Minimal configuration
+		p := New(
+			"testdata",
+			"",
+			"",
+			false,
+			false,
+			false,
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			map[Type]bool{},
+		)
+		_, _, err := p.ParseTree()
+		if err != nil {
+			b.Fatalf("Error parsing tree: %v", err)
+		}
+	}
+}
+
+func BenchmarkParseTreeWithNumbers(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Numbers enabled
+		p := New(
+			"testdata",
+			"",
+			"",
+			false,
+			false,
+			true, // Parse numbers
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			map[Type]bool{},
+		)
+		_, _, err := p.ParseTree()
+		if err != nil {
+			b.Fatalf("Error parsing tree: %v", err)
+		}
+	}
+}
+
+func BenchmarkParseTreeWithConstMatch(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Match constants enabled
+		p := New(
+			"testdata",
+			"",
+			"",
+			false,
+			true, // Match constants
+			false,
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			map[Type]bool{},
+		)
+		_, _, err := p.ParseTree()
+		if err != nil {
+			b.Fatalf("Error parsing tree: %v", err)
+		}
+	}
+}
+
+// BenchmarkStringInterning benchmarks the performance improvement from string interning
+func BenchmarkStringInterning(b *testing.B) {
+	b.ReportAllocs()
+	
+	// Generate some test data
+	testData := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		// Create strings that will sometimes be duplicates
+		testData[i] = fmt.Sprintf("test-string-%d", i%20)
+	}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := New(
+			"",
+			"",
+			"",
+			false,
+			false,
+			false,
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			nil,
+		)
+		
+		// Simulate processing these strings
+		for _, s := range testData {
+			// Intern the string
+			interned := InternString(s)
+			
+			// Do something with the interned string to prevent optimization
+			if len(interned) > 0 {
+				p.stringCount[interned]++
+			}
+		}
+	}
+}
+
+// BenchmarkParseTreeLargeCodebase benchmarks parsing a larger codebase
+func BenchmarkParseTreeLargeCodebase(b *testing.B) {
+	// Skip if not running in CI or explicitly requested with BENCH_LARGE=1
+	if os.Getenv("CI") != "true" && os.Getenv("BENCH_LARGE") != "1" {
+		b.Skip("Skipping large benchmark; run with BENCH_LARGE=1 to enable")
+	}
+	
+	// Use the parent directory of the current workspace as test data
+	// This gives us a real-world codebase to analyze
+	wd, err := os.Getwd()
+	if err != nil {
+		b.Fatalf("Failed to get working directory: %v", err)
+	}
+	
+	// Go up one level to get parent directory
+	testPath := filepath.Dir(wd)
+	
+	b.ReportAllocs()
+	b.ResetTimer()
+	
+	for i := 0; i < b.N; i++ {
+		p := New(
+			testPath,
+			"",
+			"",
+			true, // Ignore tests to reduce volume
+			false,
+			false,
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			nil, // No type exclusions
+		)
+		_, _, err := p.ParseTree()
+		if err != nil {
+			b.Fatalf("Error parsing tree: %v", err)
+		}
+	}
+}
+
+// BenchmarkStringPooling benchmarks the performance impact of string pooling
+func BenchmarkStringPooling(b *testing.B) {
+	b.ReportAllocs()
+	
+	// Create a set of strings to process with some duplication
+	testStrings := make([]string, 10000)
+	for i := 0; i < len(testStrings); i++ {
+		testStrings[i] = fmt.Sprintf("test-string-%d", i%500)
+	}
+	
+	b.ResetTimer()
+	
+	for i := 0; i < b.N; i++ {
+		p := New(
+			"",
+			"",
+			"",
+			false,
+			false,
+			false,
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			nil, // No type exclusions
+		)
+		
+		// Simulate processing all strings
+		for _, s := range testStrings {
+			// Use intern to ensure string deduplication
+			internedString := InternString(s)
+			p.stringCount[internedString]++
+			
+			// Simulate position tracking (simplified)
+			if _, ok := p.strs[internedString]; !ok {
+				p.strs[internedString] = make([]ExtendedPos, 0, 4)
+			}
+		}
+	}
+}
+
+// BenchmarkParallelProcessing benchmarks the performance of parallel file processing
+func BenchmarkParallelProcessing(b *testing.B) {
+	// Use the testdata directory which should have multiple files
+	testPath := filepath.Join(".", "testdata")
+	
+	// Ensure the test directory exists
+	if _, err := os.Stat(testPath); os.IsNotExist(err) {
+		b.Skipf("Test data directory %q does not exist", testPath)
+	}
+	
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		p := New(
+			testPath,
+			"",
+			"",
+			false,
+			false,
+			false,
+			false,
+			false, // evalConstExpressions
+			0,
+			0,
+			3,
+			2,
+			map[Type]bool{},
+		)
+
+		// Set the concurrency level
+		p.SetConcurrency(runtime.NumCPU())
+
+		b.StartTimer()
+		_, _, err := p.ParseTree()
+		if err != nil {
+			b.Fatalf("parse failed: %v", err)
+		}
+	}
 }

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -42,7 +42,6 @@ func BenchmarkParseSampleFile(b *testing.B) {
 			p:           p,
 			fileSet:     fset,
 			packageName: "testdata",
-			fileName:    "testdata/sample.go",
 		}
 
 		ast.Walk(v, f)
@@ -64,9 +63,13 @@ func BenchmarkRun(b *testing.B) {
 		EvalConstExpressions: false, // Disable for benchmark
 	}
 
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		_, err := Run([]*ast.File{f}, fset, config)
+		_, err := Run([]*ast.File{f}, fset, info, config)
 		if err != nil {
 			b.Fatalf("Run() error = %v", err)
 		}

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -27,6 +27,7 @@ Flags:
   -min-length        only report strings with the minimum given length (default: 3)
   -match-constant    look for existing constants matching the strings
   -find-duplicates   look for constants with identical values
+  -eval-const-expr   enable evaluation of constant expressions (e.g., Prefix + "suffix")
   -numbers           search also for duplicated numbers
   -min               minimum value, only works with -numbers
   -max               maximum value, only works with -numbers
@@ -41,6 +42,7 @@ Examples:
   goconst -min-occurrences 3 -output json $GOPATH/src/github.com/cockroachdb/cockroach
   goconst -numbers -min 60 -max 512 .
   goconst -min-occurrences 5 $(go list -m -f '{{.Dir}}')
+  goconst -eval-const-expr -match-constant . # Matches constant expressions like Prefix + "suffix"
 `
 
 var (
@@ -51,6 +53,7 @@ var (
 	flagMinLength      = flag.Int("min-length", 3, "only report strings with the minimum given length")
 	flagMatchConstant  = flag.Bool("match-constant", false, "look for existing constants matching the strings")
 	flagFindDuplicates = flag.Bool("find-duplicates", false, "look for constants with duplicated values")
+	flagEvalConstExpr  = flag.Bool("eval-const-expr", false, "enable evaluation of constant expressions (e.g., Prefix + \"suffix\")")
 	flagNumbers        = flag.Bool("numbers", false, "search also for duplicated numbers")
 	flagMin            = flag.Int("min", 0, "minimum value, only works with -numbers")
 	flagMax            = flag.Int("max", 0, "maximum value, only works with -numbers")
@@ -108,6 +111,7 @@ func run(path string) (bool, error) {
 		*flagMatchConstant,
 		*flagNumbers,
 		*flagFindDuplicates,
+		*flagEvalConstExpr,
 		*flagMin,
 		*flagMax,
 		*flagMinLength,

--- a/compat/compat_test.go
+++ b/compat/compat_test.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"go/token"
+	"go/types"
 	"testing"
 
 	goconstAPI "github.com/jgautheron/goconst"
@@ -10,70 +11,74 @@ import (
 // TestGolangCICompatibility verifies that our API remains compatible
 // with how golangci-lint uses it
 func TestGolangCICompatibility(t *testing.T) {
-  // This test mimics how golangci-lint configures and uses goconst
-  // See: https://github.com/golangci/golangci-lint/blob/main/pkg/golinters/goconst/goconst.go
-  
-  cfg := goconstAPI.Config{
-    IgnoreStrings: []string{"test"},
-    MatchWithConstants: true,
-    MinStringLength: 3,
-    MinOccurrences: 2,
-    ParseNumbers: true,
-    NumberMin: 100,
-    NumberMax: 1000,
-    ExcludeTypes: map[goconstAPI.Type]bool{
-      goconstAPI.Call: true,
-    },
-    IgnoreTests: false,
-    EvalConstExpressions: true,
-  }
+	// This test mimics how golangci-lint configures and uses goconst
+	// See: https://github.com/golangci/golangci-lint/blob/main/pkg/golinters/goconst/goconst.go
 
-  // Create a simple test file
-  fset := token.NewFileSet()
-  
-  // Verify that the API call signature matches what golangci-lint expects
-  _, err := goconstAPI.Run(nil, fset, &cfg)
-  if err != nil {
-    // We expect an error since we passed nil files
-    // but the important part is that the function signature matches
-    t.Log("Expected error from nil files:", err)
-  }
+	cfg := goconstAPI.Config{
+		IgnoreStrings:      []string{"test"},
+		MatchWithConstants: true,
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		ParseNumbers:       true,
+		NumberMin:          100,
+		NumberMax:          1000,
+		ExcludeTypes: map[goconstAPI.Type]bool{
+			goconstAPI.Call: true,
+		},
+		IgnoreTests:          false,
+		EvalConstExpressions: true,
+	}
 
-  // Verify that the Issue struct has all fields golangci-lint expects
-  issue := goconstAPI.Issue{
-    Pos: token.Position{},
-    OccurrencesCount: 2,
-    Str: "test",
-    MatchingConst: "TEST",
-  }
+	// Create a simple test file
+	fset := token.NewFileSet()
 
-  // Verify we can access all fields golangci-lint uses
-  _ = issue.Pos
-  _ = issue.OccurrencesCount
-  _ = issue.Str
-  _ = issue.MatchingConst
+	info := &types.Info{}
+
+	// Verify that the API call signature matches what golangci-lint expects
+	_, err := goconstAPI.Run(nil, fset, info, &cfg)
+	if err != nil {
+		// We expect an error since we passed nil files
+		// but the important part is that the function signature matches
+		t.Log("Expected error from nil files:", err)
+	}
+
+	// Verify that the Issue struct has all fields golangci-lint expects
+	issue := goconstAPI.Issue{
+		Pos:              token.Position{},
+		OccurrencesCount: 2,
+		Str:              "test",
+		MatchingConst:    "TEST",
+	}
+
+	// Verify we can access all fields golangci-lint uses
+	_ = issue.Pos
+	_ = issue.OccurrencesCount
+	_ = issue.Str
+	_ = issue.MatchingConst
 }
 
 // TestMultipleIgnorePatterns verifies that multiple ignore patterns work correctly
 func TestMultipleIgnorePatterns(t *testing.T) {
-  // Test configuration with multiple ignore patterns
-  cfg := goconstAPI.Config{
-    IgnoreStrings: []string{"foo.+", "bar.+", "test"},
-    MinStringLength: 3,
-    MinOccurrences: 2,
-  }
+	// Test configuration with multiple ignore patterns
+	cfg := goconstAPI.Config{
+		IgnoreStrings:   []string{"foo.+", "bar.+", "test"},
+		MinStringLength: 3,
+		MinOccurrences:  2,
+	}
 
-  // Create a simple test file
-  fset := token.NewFileSet()
-  
-  // We just want to verify that multiple patterns are accepted
-  _, err := goconstAPI.Run(nil, fset, &cfg)
-  if err != nil {
-    // We expect an error since we passed nil files
-    // but the important part is that multiple patterns are accepted
-    t.Log("Expected error from nil files:", err)
-  }
+	// Create a simple test file
+	fset := token.NewFileSet()
 
-  // This tests the construction and acceptance of the config
-  // Actual pattern matching is tested in integration tests
-} 
+	info := &types.Info{}
+
+	// We just want to verify that multiple patterns are accepted
+	_, err := goconstAPI.Run(nil, fset, info, &cfg)
+	if err != nil {
+		// We expect an error since we passed nil files
+		// but the important part is that multiple patterns are accepted
+		t.Log("Expected error from nil files:", err)
+	}
+
+	// This tests the construction and acceptance of the config
+	// Actual pattern matching is tested in integration tests
+}

--- a/compat/compat_test.go
+++ b/compat/compat_test.go
@@ -25,6 +25,7 @@ func TestGolangCICompatibility(t *testing.T) {
       goconstAPI.Call: true,
     },
     IgnoreTests: false,
+    EvalConstExpressions: true,
   }
 
   // Create a simple test file

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,6 +15,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 		numberMax       int
 		minLength       int
 		findDuplicates  bool
+		evalConstExpr   bool
 		minOccurrences  int
 		expectedStrings int
 		expectedMatches map[string]string // string -> expected matching constant
@@ -25,9 +26,11 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			ignoreTests:     false,
 			matchConstant:   false,
 			numbers:         false,
+			findDuplicates:  false,
+			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 7, // All strings that appear at least twice
+			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
 		},
 		{
 			name:            "match with constants",
@@ -35,14 +38,18 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			ignoreTests:     false,
 			matchConstant:   true,
 			numbers:         false,
+			findDuplicates:  false,
+			evalConstExpr:   true, // Enable constant expression evaluation for this test
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 7, // All strings that appear at least twice
+			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
 			expectedMatches: map[string]string{
 				"single constant":              "SingleConst",
 				"grouped constant":             "GroupedConst1",
 				"duplicate value":              "DuplicateConst1",
 				"special\nvalue\twith\rchars":  "SpecialConst",
+				"example.com/api":              "API",       // from const_expressions.go
+				"example.com/web":              "Web",       // from const_expressions.go
 			},
 		},
 		{
@@ -51,9 +58,11 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			ignoreTests:     false,
 			matchConstant:   false,
 			numbers:         true,
+			findDuplicates:  false,
+			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 8, // All strings + "12345"
+			expectedStrings: 10, // All strings + "12345" (8 original + 2 from const_expressions.go)
 		},
 		{
 			name:            "filter by number range",
@@ -63,9 +72,11 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			numbers:         true,
 			numberMin:       100,
 			numberMax:       1000,
+			findDuplicates:  false,
+			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 7, // All strings, 12345 should be filtered out
+			expectedStrings: 9, // All strings, 12345 should be filtered out (7 original + 2 from const_expressions.go)
 		},
 		{
 			name:            "higher minimum occurrences",
@@ -73,6 +84,8 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			ignoreTests:     false,
 			matchConstant:   false,
 			numbers:         false,
+			findDuplicates:  false,
+			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  5, // higher than any string in our testdata
 			expectedStrings: 1, // "test context" appears exactly 5 times
@@ -89,6 +102,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 				tt.matchConstant,
 				tt.numbers,
 				tt.findDuplicates,
+				tt.evalConstExpr,
 				tt.numberMin,
 				tt.numberMax,
 				tt.minLength,
@@ -139,12 +153,12 @@ func TestIntegrationExcludeTypes(t *testing.T) {
 		{
 			name:            "no exclusions",
 			excludeTypes:    map[Type]bool{},
-			expectedStrings: 7, // All strings that appear at least twice
+			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
 		},
 		{
 			name:            "exclude assignments",
 			excludeTypes:    map[Type]bool{Assignment: true},
-			expectedStrings: 3, // After excluding assignments, only "test context", "grouped constant", and "matched" remain
+			expectedStrings: 3, // After excluding assignments
 		},
 		{
 			name: "exclude all types",
@@ -169,6 +183,7 @@ func TestIntegrationExcludeTypes(t *testing.T) {
 				false, // matchConstant
 				false, // numbers
 				false, // findDuplicates
+				false, // evalConstExpressions
 				0,     // numberMin
 				0,     // numberMax
 				3,     // minLength

--- a/integration_test.go
+++ b/integration_test.go
@@ -44,12 +44,12 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			minOccurrences:  2,
 			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
 			expectedMatches: map[string]string{
-				"single constant":              "SingleConst",
-				"grouped constant":             "GroupedConst1",
-				"duplicate value":              "DuplicateConst1",
-				"special\nvalue\twith\rchars":  "SpecialConst",
-				"example.com/api":              "API",       // from const_expressions.go
-				"example.com/web":              "Web",       // from const_expressions.go
+				"single constant":             "SingleConst",
+				"grouped constant":            "GroupedConst1",
+				"duplicate value":             "DuplicateConst1",
+				"special\nvalue\twith\rchars": "SpecialConst",
+				"example.com/api":             "API", // from const_expressions.go
+				"example.com/web":             "Web", // from const_expressions.go
 			},
 		},
 		{

--- a/match_constant_test.go
+++ b/match_constant_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestMatchConstant(t *testing.T) {
 	tests := []struct {
-		name           string
-		code           string
-		wantIssues    int
-		wantMatches   map[string]string // string -> matching const name
+		name        string
+		code        string
+		wantIssues  int
+		wantMatches map[string]string // string -> matching const name
 	}{
 		{
 			name: "basic constant match",
@@ -143,7 +143,10 @@ func example() {
 				MatchWithConstants: true,
 			}
 
-			issues, err := Run([]*ast.File{f}, fset, config)
+			chkr, info := checker(fset)
+			_ = chkr.Files([]*ast.File{f})
+
+			issues, err := Run([]*ast.File{f}, fset, info, config)
 			if err != nil {
 				t.Fatalf("Run() error = %v", err)
 			}
@@ -159,7 +162,7 @@ func example() {
 			for _, issue := range issues {
 				if wantConst, ok := tt.wantMatches[issue.Str]; ok {
 					if issue.MatchingConst != wantConst {
-						t.Errorf("String %q matched with constant %q, want %q", 
+						t.Errorf("String %q matched with constant %q, want %q",
 							issue.Str, issue.MatchingConst, wantConst)
 					}
 				} else {
@@ -202,7 +205,10 @@ func main() {
 		MatchWithConstants: true,
 	}
 
-	issues, err := Run(astFiles, fset, config)
+	chkr, info := checker(fset)
+	_ = chkr.Files(astFiles)
+
+	issues, err := Run(astFiles, fset, info, config)
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
@@ -230,11 +236,11 @@ func main() {
 
 func TestMatchConstantExpressions(t *testing.T) {
 	tests := []struct {
-		name           string
-		code           string
-		evalExpr       bool
-		wantIssues     int
-		wantMatches    map[string]string // string -> matching const name
+		name        string
+		code        string
+		evalExpr    bool
+		wantIssues  int
+		wantMatches map[string]string // string -> matching const name
 	}{
 		{
 			name: "simple string concatenation",
@@ -246,7 +252,7 @@ const (
 func example() {
 	path := "api.users"
 }`,
-			evalExpr: true,
+			evalExpr:   true,
 			wantIssues: 1,
 			wantMatches: map[string]string{
 				"api.users": "Endpoint",
@@ -263,7 +269,7 @@ const (
 func example() {
 	url := "example.com/api/v1"
 }`,
-			evalExpr: true,
+			evalExpr:   true,
 			wantIssues: 1,
 			wantMatches: map[string]string{
 				"example.com/api/v1": "FullURL",
@@ -279,7 +285,7 @@ const (
 func example() {
 	msg := "ERROR: invalid\ninput"
 }`,
-			evalExpr: true,
+			evalExpr:   true,
 			wantIssues: 1,
 			wantMatches: map[string]string{
 				"ERROR: invalid\ninput": "ErrorMsg",
@@ -297,7 +303,7 @@ const (
 func example() {
 	val := "abcd"
 }`,
-			evalExpr: true,
+			evalExpr:   true,
 			wantIssues: 1,
 			wantMatches: map[string]string{
 				"abcd": "D",
@@ -313,8 +319,8 @@ const (
 func example() {
 	path := "api.users"
 }`,
-			evalExpr: false,
-			wantIssues: 1,  // Still detects the string, but no matching constant
+			evalExpr:   false,
+			wantIssues: 1, // Still detects the string, but no matching constant
 			wantMatches: map[string]string{
 				"api.users": "", // Empty string indicates no constant match
 			},
@@ -330,7 +336,7 @@ const (
 func example() {
 	val := "abc"
 }`,
-			evalExpr: true,
+			evalExpr:   true,
 			wantIssues: 1,
 			wantMatches: map[string]string{
 				"abc": "Combined",
@@ -353,7 +359,10 @@ func example() {
 				EvalConstExpressions: tt.evalExpr,
 			}
 
-			issues, err := Run([]*ast.File{f}, fset, config)
+			chkr, info := checker(fset)
+			_ = chkr.Files([]*ast.File{f})
+
+			issues, err := Run([]*ast.File{f}, fset, info, config)
 			if err != nil {
 				t.Fatalf("Run() error = %v", err)
 			}
@@ -370,7 +379,7 @@ func example() {
 			for _, issue := range issues {
 				if wantConst, ok := tt.wantMatches[issue.Str]; ok {
 					if issue.MatchingConst != wantConst {
-						t.Errorf("String %q matched with constant %q, want %q", 
+						t.Errorf("String %q matched with constant %q, want %q",
 							issue.Str, issue.MatchingConst, wantConst)
 					}
 				} else {
@@ -379,4 +388,4 @@ func example() {
 			}
 		})
 	}
-} 
+}

--- a/match_constant_test.go
+++ b/match_constant_test.go
@@ -226,4 +226,157 @@ func main() {
 			t.Errorf("Unexpected string found: %q", issue.Str)
 		}
 	}
+}
+
+func TestMatchConstantExpressions(t *testing.T) {
+	tests := []struct {
+		name           string
+		code           string
+		evalExpr       bool
+		wantIssues     int
+		wantMatches    map[string]string // string -> matching const name
+	}{
+		{
+			name: "simple string concatenation",
+			code: `package example
+const (
+	Prefix = "api."
+	Endpoint = Prefix + "users"
+)
+func example() {
+	path := "api.users"
+}`,
+			evalExpr: true,
+			wantIssues: 1,
+			wantMatches: map[string]string{
+				"api.users": "Endpoint",
+			},
+		},
+		{
+			name: "nested expressions",
+			code: `package example
+const (
+	BaseURL = "example.com"
+	APIPath = "/api/v1"
+	FullURL = BaseURL + APIPath
+)
+func example() {
+	url := "example.com/api/v1"
+}`,
+			evalExpr: true,
+			wantIssues: 1,
+			wantMatches: map[string]string{
+				"example.com/api/v1": "FullURL",
+			},
+		},
+		{
+			name: "expressions with special characters",
+			code: `package example
+const (
+	ErrorPrefix = "ERROR: "
+	ErrorMsg = ErrorPrefix + "invalid\ninput"
+)
+func example() {
+	msg := "ERROR: invalid\ninput"
+}`,
+			evalExpr: true,
+			wantIssues: 1,
+			wantMatches: map[string]string{
+				"ERROR: invalid\ninput": "ErrorMsg",
+			},
+		},
+		{
+			name: "multiple levels of indirection",
+			code: `package example
+const (
+	A = "a"
+	B = A + "b"
+	C = B + "c"
+	D = C + "d"
+)
+func example() {
+	val := "abcd"
+}`,
+			evalExpr: true,
+			wantIssues: 1,
+			wantMatches: map[string]string{
+				"abcd": "D",
+			},
+		},
+		{
+			name: "constant expression - feature disabled",
+			code: `package example
+const (
+	Prefix = "api."
+	Endpoint = Prefix + "users"
+)
+func example() {
+	path := "api.users"
+}`,
+			evalExpr: false,
+			wantIssues: 1,  // Still detects the string, but no matching constant
+			wantMatches: map[string]string{
+				"api.users": "", // Empty string indicates no constant match
+			},
+		},
+		{
+			name: "parenthesized expressions",
+			code: `package example
+const (
+	A = "a"
+	B = "b"
+	Combined = (A + B) + "c"
+)
+func example() {
+	val := "abc"
+}`,
+			evalExpr: true,
+			wantIssues: 1,
+			wantMatches: map[string]string{
+				"abc": "Combined",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "example.go", tt.code, 0)
+			if err != nil {
+				t.Fatalf("Failed to parse test code: %v", err)
+			}
+
+			config := &Config{
+				MinStringLength:      1, // Set to 1 to catch all strings
+				MinOccurrences:       1, // Set to 1 to catch all occurrences
+				MatchWithConstants:   true,
+				EvalConstExpressions: tt.evalExpr,
+			}
+
+			issues, err := Run([]*ast.File{f}, fset, config)
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			if len(issues) != tt.wantIssues {
+				t.Errorf("Got %d issues, want %d", len(issues), tt.wantIssues)
+				for _, issue := range issues {
+					t.Logf("Found issue: %q matches constant %q", issue.Str, issue.MatchingConst)
+				}
+				return
+			}
+
+			// Verify constant matches
+			for _, issue := range issues {
+				if wantConst, ok := tt.wantMatches[issue.Str]; ok {
+					if issue.MatchingConst != wantConst {
+						t.Errorf("String %q matched with constant %q, want %q", 
+							issue.Str, issue.MatchingConst, wantConst)
+					}
+				} else {
+					t.Errorf("Unexpected string found: %q", issue.Str)
+				}
+			}
+		})
+	}
 } 

--- a/parser.go
+++ b/parser.go
@@ -298,9 +298,14 @@ func (p *Parser) ParseTree() (Strings, Constants, error) {
 	}
 }
 
+const (
+	chanSize = 1000
+)
+
 // parseTreeConcurrent implements an optimized concurrent file traversal
 // that efficiently processes directories and files using worker pools.
 func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, Constants, error) {
+
 	// If batch processing is enabled, use that implementation instead
 	if p.enableBatching {
 		return p.parseTreeBatched(rootPath, recursive)
@@ -319,6 +324,16 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 		if err != nil {
 			return nil, nil, err
 		}
+		// run type checker
+		info := &types.Info{
+			Types: make(map[ast.Expr]types.TypeAndValue),
+		}
+
+		chkConfig := &types.Config{
+			Error: func(err error) {}, // type checking is only used to evaluate constant expressions, so we ignore most errors
+		}
+		pkg := types.NewPackage("", f.Name.Name)
+		_ = types.NewChecker(chkConfig, fset, pkg, info).Files([]*ast.File{f})
 
 		// Process the file
 		ast.Walk(&treeVisitor{
@@ -326,7 +341,7 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 			packageName: f.Name.Name,
 			p:           p,
 			ignoreRegex: p.ignoreStringsRegex,
-			typeInfo:
+			typeInfo:    info,
 		}, f)
 
 		// Post-process and filter results
@@ -335,7 +350,7 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 	}
 
 	// Create a channel to collect all files to be processed
-	filesChan := make(chan string, 1000)
+	filesChan := make(chan string, chanSize)
 
 	// Start a goroutine to collect all Go files
 	var wg sync.WaitGroup
@@ -415,25 +430,41 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 		}
 	}()
 
+	fset, filesByPackage := p.parseConcurrently(filesChan)
+
+	wg.Wait()
+
+	// TODO: what type-checking information is needed for correctly evaluating cross-package consts?
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+	}
+
+	// run type-checker
+	p.typeCheckConcurrently(fset, info, filesByPackage)
+
+	// Visit all files
+	p.visitConcurrently(fset, info, filesByPackage)
+
+	// Post-process and filter results
+	p.ProcessResults()
+
+	return p.strs, p.consts, nil
+}
+
+func (p *Parser) parseConcurrently(filesChan <-chan string) (*token.FileSet, map[string][]*ast.File) {
 	// Start file parser workers
 	var parserWg sync.WaitGroup
 
-	// Reuse FileSet in each worker
 	fset := p.getFileSet()
 
-	type parsedFile struct {
-		pkgName string
-		f       *ast.File
-	}
-	parsedFilesChan := make(chan parsedFile)
+	parsedFilesChan := make(chan parsedFile, chanSize)
 
 	for i := 0; i < p.maxConcurrency; i++ {
 		parserWg.Add(1)
 		go func(id int) {
 			defer func() {
 				parserWg.Done()
-				// first worker waits and closes channel
-				if id == 0 {
+				if id == 0 { // first worker waits and closes the sending channel
 					parserWg.Wait()
 					close(parsedFilesChan)
 				}
@@ -460,70 +491,90 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 		}(i)
 	}
 
-	// read all parsed files into packgageFiles map
+	// Read all parsed files into packgageFiles map. All packages must be parsed prior to type-checking.
+	fileCount := 0
 	packageFiles := map[string][]*ast.File{}
+
 	var readerWg sync.WaitGroup
 	readerWg.Add(1)
 	go func() {
 		defer readerWg.Done()
 		for parsed := range parsedFilesChan {
 			packageFiles[parsed.pkgName] = append(packageFiles[parsed.pkgName], parsed.f)
+			fileCount++ // safe since this is single-threaded.
 		}
 	}()
 
-	// Wait for all file collection to complete
-	wg.Wait()
 	// Wait for all file parsing to complete
 	parserWg.Wait()
-	// Wait for  to complete
+	// Wait for collection to complete
 	readerWg.Wait()
 
-	// Start type checker
-	info := &types.Info{
-		Types: make(map[ast.Expr]types.TypeAndValue),
-	}
+	return fset, packageFiles
+}
 
-	packages := map[string]*types.Package{}
+func (p *Parser) typeCheckConcurrently(fset *token.FileSet, info *types.Info, filesByPackage map[string][]*ast.File) {
+	type parsedPackage struct {
+		pkgName string
+		files   []*ast.File
+	}
+	pkgChan := make(chan parsedPackage, chanSize)
+
 	chkConfig := &types.Config{
-		Error: func(err error) {}, // type checking is only used to evaluat. constant expressions, so we ignore most errors
-	}
-	for pkgName, files := range packageFiles {
-		_, ok := packages[pkgName]
-		if !ok {
-			packages[pkgName] = types.NewPackage("", pkgName)
-		}
-		chk := types.NewChecker(chkConfig, fset, packages[pkgName], info)
-
-		if err := chk.Files(files); err != nil {
-			continue // ignore any constant expressions with type checking errors.
-		}
+		Error: func(err error) {}, // type checking is only used to evaluate constant expressions, so we ignore most errors
 	}
 
-	// Visit all files
+	var wg sync.WaitGroup
+	for i := 0; i < p.maxConcurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for pkg := range pkgChan {
+				chk := types.NewChecker(chkConfig, fset, types.NewPackage("", pkg.pkgName), info)
+
+				_ = chk.Files(pkg.files)
+			}
+		}()
+	}
+
+	for pkgName, files := range filesByPackage {
+		pkgChan <- parsedPackage{pkgName: pkgName, files: files}
+	}
+	close(pkgChan)
+
+	wg.Wait()
+}
+
+// visitConcurrently visits all files in filesByPackage on a worker pool goroutines.
+func (p *Parser) visitConcurrently(fset *token.FileSet, info *types.Info, filesByPackage map[string][]*ast.File) {
 	var visitorWg sync.WaitGroup
 
-	for pkgName, files := range packageFiles {
-		for _, f := range files {
-			visitorWg.Add(1)
-			go func(pkgName string, f *ast.File) {
-				defer visitorWg.Done()
+	parsedFilesChan := make(chan parsedFile, chanSize)
+
+	for i := 0; i < p.maxConcurrency; i++ {
+		visitorWg.Add(1)
+		go func() {
+			defer visitorWg.Done()
+			for pf := range parsedFilesChan {
 				ast.Walk(&treeVisitor{
 					fileSet:     fset,
 					typeInfo:    info,
-					packageName: pkgName,
+					packageName: pf.pkgName,
 					p:           p,
 					ignoreRegex: p.ignoreStringsRegex,
-				}, f)
-			}(pkgName, f)
-		}
+				}, pf.f)
+			}
+		}()
 	}
 
+	for pkgName, files := range filesByPackage {
+		for _, f := range files {
+			parsedFilesChan <- parsedFile{pkgName, f}
+		}
+	}
+	close(parsedFilesChan)
+
 	visitorWg.Wait()
-
-	// Post-process and filter results
-	p.ProcessResults()
-
-	return p.strs, p.consts, nil
 }
 
 // parseTreeBatched implements batch processing for very large codebases.
@@ -531,7 +582,10 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 // in batches and processes each batch completely before moving to the next.
 // This helps manage memory usage for extremely large codebases.
 func (p *Parser) parseTreeBatched(rootPath string, recursive bool) (Strings, Constants, error) {
-	var allFiles []string
+	var (
+		allFiles      []string
+		allFilesByDir = make(map[string][]string)
+	)
 
 	// First, collect all file paths that need to be processed
 	if recursive {
@@ -555,6 +609,8 @@ func (p *Parser) parseTreeBatched(rootPath string, recursive bool) (Strings, Con
 				}
 
 				allFiles = append(allFiles, path)
+				dir := filepath.Dir(path)
+				allFilesByDir[dir] = append(allFilesByDir[dir], path)
 			}
 
 			return nil
@@ -590,68 +646,69 @@ func (p *Parser) parseTreeBatched(rootPath string, recursive bool) (Strings, Con
 				}
 
 				allFiles = append(allFiles, path)
+				allFilesByDir[rootPath] = append(allFilesByDir[rootPath], path)
 			}
 		}
 	}
 
-	// Process files in batches
-	totalFiles := len(allFiles)
-	log.Printf("Found %d Go files to process in batches of %d", totalFiles, p.batchSize)
+	// Split into batches, ensuring each package's files are all in the same batch, since the typechecker requires
+	// entire packages. Some batches may exceed the requested batchSize.
+	totalFiles := 0
+	largeBatches := 0
+	maxBatchSize := 0
 
-	for i := 0; i < totalFiles; i += p.batchSize {
-		end := i + p.batchSize
-		if end > totalFiles {
-			end = totalFiles
+	var batches [][]string
+	var currBatch []string
+	for _, pkgFiles := range allFilesByDir {
+		size := len(currBatch)
+		if size >= p.batchSize {
+			batches = append(batches, currBatch)
+			currBatch = nil
 		}
+		currBatch = append(currBatch, pkgFiles...)
 
-		batch := allFiles[i:end]
-		log.Printf("Processing batch %d/%d (%d files)", (i/p.batchSize)+1, (totalFiles+p.batchSize-1)/p.batchSize, len(batch))
+		// compute some stats
+		if size >= p.batchSize {
+			largeBatches++
+		}
+		if size >= maxBatchSize {
+			maxBatchSize = size
+		}
+		totalFiles += len(pkgFiles)
+	}
+	if len(currBatch) > 0 {
+		batches = append(batches, currBatch)
+	}
+
+	// Process batches
+	log.Printf("Found %d Go files to process in batches of %d", totalFiles, p.batchSize)
+	if largeBatches > 0 {
+		log.Printf("Warning: %d batches exceed the configured batch size. Largest batch contains %d files", largeBatches, maxBatchSize)
+	}
+
+	for i, batch := range batches {
+		log.Printf("Processing batch %d/%d (%d files)", i+1, len(batches), len(batch))
 
 		// Process this batch concurrently
-		var wg sync.WaitGroup
-		fileChan := make(chan string, len(batch))
-
-		// Start file processor workers
-		for j := 0; j < p.maxConcurrency; j++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				fset := token.NewFileSet()
-
-				for filePath := range fileChan {
-					// Process each file
-					src, err := p.readFileEfficiently(filePath)
-					if err != nil {
-						log.Printf("Error reading file %s: %v", filePath, err)
-						continue
-					}
-
-					f, err := parser.ParseFile(fset, filePath, src, 0)
-					if err != nil {
-						log.Printf("Error parsing file %s: %v", filePath, err)
-						continue
-					}
-
-					// Process the file
-					pkgName := f.Name.Name
-					ast.Walk(&treeVisitor{
-						fileSet:     fset,
-						packageName: pkgName,
-						p:           p,
-						ignoreRegex: p.ignoreStringsRegex,
-					}, f)
-				}
-			}()
-		}
 
 		// Queue all files in this batch
+		fileChan := make(chan string, len(batch))
 		for _, filePath := range batch {
 			fileChan <- filePath
 		}
+		close(fileChan) // safe to close since len(fileChan) == len(batch)
 
-		// Close the channel and wait for processing to complete
-		close(fileChan)
-		wg.Wait()
+		fset, filesByPackage := p.parseConcurrently(fileChan)
+
+		info := &types.Info{
+			Types: make(map[ast.Expr]types.TypeAndValue),
+		}
+
+		// run type-checker
+		p.typeCheckConcurrently(fset, info, filesByPackage)
+
+		// Visit all files
+		p.visitConcurrently(fset, info, filesByPackage)
 
 		// Optional: Run garbage collection between batches for very large codebases
 		if totalFiles > 10000 && len(batch) >= 1000 {
@@ -810,6 +867,11 @@ func (p *Parser) ProcessResults() {
 			}
 		}
 	}
+}
+
+type parsedFile struct {
+	pkgName string
+	f       *ast.File
 }
 
 // Strings maps string literals to their positions in the code.

--- a/parser_test.go
+++ b/parser_test.go
@@ -137,7 +137,8 @@ func TestParser_New(t *testing.T) {
 		true, // ignoreTests
 		true, // matchConstant
 		true, // numbers
-		true, //findDuplicates
+		true, // findDuplicates
+		false, // evalConstExpressions
 		100,  // numberMin
 		500,  // numberMax
 		3,    // minLength
@@ -275,7 +276,8 @@ func test() {
 				tt.ignoreTests,
 				tt.matchConstant,
 				tt.numbers,
-				false, // TODO: test
+				false, // findDuplicates
+				false, // evalConstExpressions
 				0,     // numberMin
 				0,     // numberMax
 				tt.minLength,
@@ -322,6 +324,7 @@ func nested() {
 			false,         // matchConstant
 			false,         // numbers
 			false,         // findDuplicates
+			false,         // evalConstExpressions
 			0,             // numberMin
 			0,             // numberMax
 			3,             // minLength
@@ -398,9 +401,10 @@ func TestFunction(t *testing.T) {
 				tt.ignoreTests,
 				tt.matchConstant,
 				tt.numbers,
-				tt.findDuplicates,
-				0, // numberMin
-				0, // numberMax
+				false, // findDuplicates
+				false, // evalConstExpressions
+				0,     // numberMin
+				0,     // numberMax
 				tt.minLength,
 				tt.minOccurrences,
 				map[Type]bool{},
@@ -440,6 +444,7 @@ func ignored() {
 			false,       // matchConstant
 			false,       // numbers
 			false,       // findDuplicates
+			false,       // evalConstExpressions
 			0,           // numberMin
 			0,           // numberMax
 			3,           // minLength
@@ -488,6 +493,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 				false,
 				true,
 				false, // findDuplicates
+				false, // evalConstExpressions
 				0,
 				0,
 				3,
@@ -512,6 +518,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 				false,
 				false,
 				true,
+				false,
 				false,
 				0,
 				0,
@@ -540,6 +547,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 				false,
 				false,
 				true,
+				false,
 				false,
 				0,
 				0,
@@ -570,6 +578,7 @@ func BenchmarkFileTraversal(b *testing.B) {
 					false,
 					false,
 					true,
+					false,
 					false,
 					0,
 					0,
@@ -721,7 +730,7 @@ func BenchmarkFileReading(b *testing.B) {
 	// Test optimized file reading with different file sizes
 	for i, size := range testSizes {
 		b.Run(fmt.Sprintf("OptimizedIO_%d", size), func(b *testing.B) {
-			p := New("", "", "", false, false, false, false, 0, 0, 3, 2, map[Type]bool{})
+			p := New("", "", "", false, false, false, false, false, 0, 0, 3, 2, map[Type]bool{})
 
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {

--- a/scripts/test-golangci-compat.sh
+++ b/scripts/test-golangci-compat.sh
@@ -173,10 +173,10 @@ func constExpressions() {
     // These should be detected with matching constants when using -eval-const-expr
     path1 := "domain.com/api"
     path2 := "domain.com/api"
-    
+
     web1 := "domain.com/web"
     web2 := "domain.com/web"
-    
+
     // This is just the prefix, not a compound expression result
     prefix := "domain.com/"
 }

--- a/testdata/const_expressions.go
+++ b/testdata/const_expressions.go
@@ -1,0 +1,16 @@
+package testdata
+
+const (
+	Prefix = "example.com/"
+	API = Prefix + "api"
+	Web = Prefix + "web"
+)
+
+func testConstExpressions() {
+	// These should match the constant expressions when using -eval-const-expr
+	a := "example.com/api"
+	b := "example.com/api"
+	
+	c := "example.com/web"
+	d := "example.com/web"
+} 

--- a/visitor.go
+++ b/visitor.go
@@ -40,13 +40,20 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 
 		for _, spec := range t.Specs {
 			val := spec.(*ast.ValueSpec)
-			for i, str := range val.Values {
-				lit, ok := str.(*ast.BasicLit)
-				if !ok || !v.isSupported(lit.Kind) {
+			for i, expr := range val.Values {
+				// Handle basic literals (existing code)
+				if lit, ok := expr.(*ast.BasicLit); ok && v.isSupported(lit.Kind) {
+					v.addConst(val.Names[i].Name, lit.Value, val.Names[i].Pos())
 					continue
 				}
-
-				v.addConst(val.Names[i].Name, lit.Value, val.Names[i].Pos())
+				
+				// Handle constant expressions
+				if v.p.evalConstExpressions {
+					// Try to evaluate constant expressions using Go's evaluator
+					if strValue := v.evaluateConstExpr(expr); strValue != "" {
+						v.addConstWithValue(val.Names[i].Name, strValue, val.Names[i].Pos())
+					}
+				}
 			}
 		}
 
@@ -248,4 +255,107 @@ func (v *treeVisitor) isSupported(tk token.Token) bool {
 		}
 	}
 	return false
+}
+
+// evaluateConstExpr attempts to evaluate constant expressions.
+// It handles cases like Prefix + "suffix" where both are constants.
+// Returns the string value of the constant expression, or an empty string if not a string expression.
+func (v *treeVisitor) evaluateConstExpr(expr ast.Expr) string {
+	// Handle binary expressions like Prefix + "suffix"
+	if binExpr, ok := expr.(*ast.BinaryExpr); ok && binExpr.Op == token.ADD {
+		// We're only interested in string concatenation
+		leftVal := v.resolveExprToString(binExpr.X)
+		rightVal := v.resolveExprToString(binExpr.Y)
+		
+		// If both sides resolved to strings, combine them
+		if leftVal != "" && rightVal != "" {
+			return leftVal + rightVal
+		}
+	} else {
+		// Handle single identifiers (could be constants)
+		return v.resolveExprToString(expr)
+	}
+	
+	return ""
+}
+
+// resolveExprToString tries to resolve an expression to its string value.
+// Handles identifiers (looking up constants), string literals, and nested expressions.
+func (v *treeVisitor) resolveExprToString(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		// Direct string literal
+		if e.Kind == token.STRING {
+			val, err := strconv.Unquote(e.Value)
+			if err == nil {
+				return val
+			}
+			// Fall back to striping quotes manually if unquoting fails
+			if len(e.Value) >= 2 {
+				return e.Value[1 : len(e.Value)-1]
+			}
+		}
+		
+	case *ast.Ident:
+		// Reference to a constant
+		// Check if we've already seen this constant in the current package
+		v.p.constMutex.RLock()
+		defer v.p.constMutex.RUnlock()
+		
+		for val, constList := range v.p.consts {
+			for _, c := range constList {
+				// Match by name and package
+				if c.Name == e.Name && c.packageName == v.packageName {
+					return val
+				}
+			}
+		}
+		
+	case *ast.BinaryExpr:
+		// Recursively evaluate nested expressions
+		if e.Op == token.ADD {
+			left := v.resolveExprToString(e.X)
+			right := v.resolveExprToString(e.Y)
+			if left != "" && right != "" {
+				return left + right
+			}
+		}
+	
+	case *ast.ParenExpr:
+		// Handle parenthesized expressions
+		return v.resolveExprToString(e.X)
+	}
+	
+	return ""
+}
+
+// addConstWithValue adds a constant with an already evaluated string value.
+// This is similar to addConst but skips the unquoting step since the value is already processed.
+func (v *treeVisitor) addConstWithValue(name string, val string, pos token.Pos) {
+	// Skip constants with values that would be filtered anyway
+	if len(val) < v.p.minLength {
+		return
+	}
+
+	if v.ignoreRegex != nil && v.ignoreRegex.MatchString(val) {
+		return
+	}
+
+	// Use interned string to reduce memory usage
+	internedVal := InternString(val)
+	internedName := InternString(name)
+	internedPkg := InternString(v.packageName)
+
+	// Lock to safely update the shared map
+	v.p.constMutex.Lock()
+	defer v.p.constMutex.Unlock()
+
+	// track this const if this is a new const, or if we are searching for duplicate consts
+	if _, ok := v.p.consts[internedVal]; !ok || v.p.findDuplicates {
+		v.p.consts[internedVal] = append(v.p.consts[internedVal], ConstType{
+			Name:        internedName,
+			packageName: internedPkg,
+			Position:    v.fileSet.Position(pos),
+		})
+	}
 }

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -128,7 +128,6 @@ func example() {
 				p:           p,
 				fileSet:     fset,
 				packageName: "example",
-				fileName:    "example.go",
 			}
 
 			ast.Walk(v, f)
@@ -229,7 +228,6 @@ func TestTreeVisitor_AddString(t *testing.T) {
 				p:           p,
 				fileSet:     fset,
 				packageName: "example",
-				fileName:    "example.go",
 			}
 
 			v.addString(tt.str, token.Pos(1), tt.typ)


### PR DESCRIPTION
This PR uses Go's type checker to compute and use constant expressions everywhere.

This will close #32 and will additionally support arbitrary numerical calculations when `-numbers` is set.

It will break compatibility with `golangci-lint`, as `goconst` will now require type information to be used. We'll need a PR upstream to plumb it through.

This PR ignores type checking errors in several locations. This is because the type checker checks a lot of extraneous information that we do not care about. The type checker can typically determine the value and type of constant expressions even if other errors are found in the file. In case type checking totally fails, `treeVisitor` falls back on its prior behavior.

Note: Since this PR casts numbers to strings prior to checking for collisions, we should have a lot more tests for various kinds of large numbers, and especially tests to check different floating point representations.