### PR TITLE
fix: invalid type for pool reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/goconst

--- a/api.go
+++ b/api.go
@@ -41,8 +41,7 @@ func PutIssueBuffer(issues []Issue) {
 		issues[i].Str = ""
 	}
 	// Return the slice to the pool
-	issuesCopy := make([]Issue, 0, cap(issues))
-	IssuePool.Put(&issuesCopy)
+	IssuePool.Put(make([]Issue, 0, cap(issues)))
 }
 
 // Config contains all configuration options for the goconst analyzer.

--- a/api.go
+++ b/api.go
@@ -41,7 +41,7 @@ func PutIssueBuffer(issues []Issue) {
 		issues[i].Str = ""
 	}
 	// Return the slice to the pool
-	IssuePool.Put(make([]Issue, 0, cap(issues)))
+	IssuePool.Put(make([]Issue, 0, cap(issues))) //nolint:staticcheck
 }
 
 // Config contains all configuration options for the goconst analyzer.

--- a/api_test.go
+++ b/api_test.go
@@ -562,3 +562,8 @@ func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
 	}
 	return types.NewChecker(cfg, fset, types.NewPackage("", "example"), info), info
 }
+
+func Test_IssuePool(t *testing.T) {
+	PutIssueBuffer([]Issue{})
+	GetIssueBuffer()
+}


### PR DESCRIPTION
The pool uses `[]goconst.Issue`, but a `*[]goconst.Issue` is used to reset the buffer.

```
=== RUN   Test_IssuePool
--- FAIL: Test_IssuePool (0.00s)
panic: interface conversion: interface {} is *[]goconst.Issue, not []goconst.Issue [recovered]
	panic: interface conversion: interface {} is *[]goconst.Issue, not []goconst.Issue

goroutine 6 [running]:
testing.tRunner.func1.2({0x62ca60, 0xc0000a2a50})
	/home/ldez/.gvm/gos/go1.23.8/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
	/home/ldez/.gvm/gos/go1.23.8/src/testing/testing.go:1635 +0x35e
panic({0x62ca60?, 0xc0000a2a50?})
	/home/ldez/.gvm/gos/go1.23.8/src/runtime/panic.go:791 +0x132
github.com/jgautheron/goconst.GetIssueBuffer(...)
	/home/ldez/sources/golangci-lint-linters/goconst/api.go:33
github.com/jgautheron/goconst.Test_IssuePool(0xc0000a8820?)
	/home/ldez/sources/golangci-lint-linters/goconst/api_test.go:568 +0x48
testing.tRunner(0xc0000a8820, 0x67cbe8)
	/home/ldez/.gvm/gos/go1.23.8/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1
	/home/ldez/.gvm/gos/go1.23.8/src/testing/testing.go:1743 +0x390

```

Related to https://github.com/jgautheron/goconst/commit/b210ef1779e6134b7df56f3c25f1fd2882236cfd