### PR TITLE
chore: update ci workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.17.x
 
-      - name: Check out code
-        uses: actions/checkout@v4
-
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
 


### PR DESCRIPTION
`actions/setup-go` is optimized to run after `actions/checkout`.