### PR TITLE
fix(visitor): detect repeated literals inside composite literal elements

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -394,6 +394,52 @@ func allContexts(param string) string {
 	}
 }
 
+func TestCompositeLiteralContexts(t *testing.T) {
+	code := `package example
+type person struct {
+	name string
+}
+
+func compositeContexts() {
+	_ = []string{"repeated literal"}
+	_ = map[string]string{
+		"first":  "repeated literal",
+		"second": "repeated literal",
+	}
+	_ = person{name: "repeated literal"}
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse test code: %v", err)
+	}
+
+	config := &Config{
+		MinStringLength: 3,
+		MinOccurrences:  4,
+	}
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, config)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	issue := issues[0]
+	if issue.Str != "repeated literal" {
+		t.Errorf("Issue.Str = %v, want %v", issue.Str, "repeated literal")
+	}
+	if issue.OccurrencesCount != 4 {
+		t.Errorf("Issue.OccurrencesCount = %v, want 4", issue.OccurrencesCount)
+	}
+}
+
 func TestExcludeByMultipleTypes(t *testing.T) {
 	// Test excluding multiple context types
 	code := `package example

--- a/integration_test.go
+++ b/integration_test.go
@@ -30,7 +30,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
+			expectedStrings: 10, // All strings that appear at least twice (7 original + 2 from const_expressions.go + 1 from composite literals)
 		},
 		{
 			name:            "match with constants",
@@ -42,7 +42,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			evalConstExpr:   true, // Enable constant expression evaluation for this test
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
+			expectedStrings: 10, // All strings that appear at least twice (7 original + 2 from const_expressions.go + 1 from composite literals)
 			expectedMatches: map[string]string{
 				"single constant":             "SingleConst",
 				"grouped constant":            "GroupedConst1",
@@ -62,7 +62,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 10, // All strings + "12345" (8 original + 2 from const_expressions.go)
+			expectedStrings: 11, // All strings + "12345" (8 original + 2 from const_expressions.go + 1 from composite literals)
 		},
 		{
 			name:            "filter by number range",
@@ -76,7 +76,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  2,
-			expectedStrings: 9, // All strings, 12345 should be filtered out (7 original + 2 from const_expressions.go)
+			expectedStrings: 10, // All strings, 12345 should be filtered out (7 original + 2 from const_expressions.go + 1 from composite literals)
 		},
 		{
 			name:            "higher minimum occurrences",
@@ -88,7 +88,7 @@ func TestIntegrationWithTestdata(t *testing.T) {
 			evalConstExpr:   false,
 			minLength:       3,
 			minOccurrences:  5, // higher than any string in our testdata
-			expectedStrings: 1, // "test context" appears exactly 5 times
+			expectedStrings: 2, // "test context" appears 5 times, "composite value" appears 5 times
 		},
 	}
 
@@ -153,21 +153,22 @@ func TestIntegrationExcludeTypes(t *testing.T) {
 		{
 			name:            "no exclusions",
 			excludeTypes:    map[Type]bool{},
-			expectedStrings: 9, // All strings that appear at least twice (7 original + 2 from const_expressions.go)
+			expectedStrings: 10, // All strings that appear at least twice (7 original + 2 from const_expressions.go + 1 from composite literals)
 		},
 		{
 			name:            "exclude assignments",
 			excludeTypes:    map[Type]bool{Assignment: true},
-			expectedStrings: 3, // After excluding assignments
+			expectedStrings: 4, // After excluding assignments (composite literals still counted)
 		},
 		{
 			name: "exclude all types",
 			excludeTypes: map[Type]bool{
-				Assignment: true,
-				Binary:     true,
-				Case:       true,
-				Return:     true,
-				Call:       true,
+				Assignment:   true,
+				Binary:       true,
+				Case:         true,
+				Return:       true,
+				Call:          true,
+				CompositeLit: true,
 			},
 			expectedStrings: 0,
 		},

--- a/parser.go
+++ b/parser.go
@@ -881,4 +881,7 @@ const (
 	Return
 	// Call represents a string passed as an argument to a function call (e.g., f("foo"))
 	Call
+	// CompositeLit represents a string inside a composite literal
+	// (e.g., []string{"foo"}, map[string]string{"k": "v"}, MyStruct{Field: "foo"})
+	CompositeLit
 )

--- a/testdata/sample.go
+++ b/testdata/sample.go
@@ -72,3 +72,13 @@ func testDuplicateConsts() {
 	// This const should be detected as a duplicate const of MatchingConst
 	const duplicate = "should be constant"
 }
+
+func testCompositeLiterals() {
+	type entry struct {
+		label string
+	}
+
+	_ = []string{"composite value", "composite value"}
+	_ = map[string]string{"composite value": "composite value"}
+	_ = entry{label: "composite value"}
+}

--- a/visitor.go
+++ b/visitor.go
@@ -116,9 +116,35 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 				v.addString(lit.Value, lit.Pos(), Call)
 			}
 		}
+
+	// []string{"foo"}, map[string]string{"k": "v"}, struct{A string}{A: "foo"}
+	case *ast.CompositeLit:
+		for _, item := range t.Elts {
+			v.addCompositeLiteralElement(item)
+		}
 	}
 
 	return v
+}
+
+func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr) {
+	if lit, ok := node.(*ast.BasicLit); ok && v.isSupported(lit.Kind) {
+		v.addString(lit.Value, lit.Pos(), CompositeLit)
+		return
+	}
+
+	kv, ok := node.(*ast.KeyValueExpr)
+	if !ok {
+		return
+	}
+
+	if keyLit, ok := kv.Key.(*ast.BasicLit); ok && v.isSupported(keyLit.Kind) {
+		v.addString(keyLit.Value, keyLit.Pos(), CompositeLit)
+	}
+
+	if valueLit, ok := kv.Value.(*ast.BasicLit); ok && v.isSupported(valueLit.Kind) {
+		v.addString(valueLit.Value, valueLit.Pos(), CompositeLit)
+	}
 }
 
 // addString adds a string in the map along with its position in the tree.

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -85,6 +85,18 @@ func example() {
 			excludeTypes:        map[Type]bool{},
 		},
 		{
+			name: "composite literal with non-literal elements",
+			code: `package example
+func example() {
+	_ = [][]string{{"nested"}}
+	_ = []string{getString()}
+}
+func getString() string { return "" }`,
+			expectedStrings:     []string{"nested"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+		},
+		{
 			name: "excluded composite literal",
 			code: `package example
 func example() {

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -69,6 +69,32 @@ func example() {
 			excludeTypes:        map[Type]bool{},
 		},
 		{
+			name: "composite literal detection",
+			code: `package example
+type person struct {
+	name string
+}
+
+func example() {
+	_ = []string{"test"}
+	_ = map[string]string{"test": "value"}
+	_ = person{name: "test"}
+}`,
+			expectedStrings:     []string{"test", "value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+		},
+		{
+			name: "excluded composite literal",
+			code: `package example
+func example() {
+	_ = []string{"test"}
+}`,
+			expectedStrings:     []string{},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{CompositeLit: true},
+		},
+		{
 			name: "excluded type assignment",
 			code: `package example
 func example() {


### PR DESCRIPTION
Implemented support for collecting repeated literals inside composite literal elements.

* Added `*ast.CompositeLit` handling in the AST visitor and extraction logic for:
  * direct literal elements like `[]string{"x"}`
  * keyed elements like `map[string]string{"k":"v"}` and `struct{...}{Field: "x"}`
* Added visitor unit tests for composite literal detection and exclusion behavior.
* Added API regression test proving repeated literals found only in composite literals are reported once `min-occurrences` is reached.

Resolves: #44 