### PR TITLE
feat: add -ignore-calls to ignore strings in specific function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Flags:
   -match-constant    look for existing constants matching the strings
   -find-duplicates   look for constants with identical values
   -eval-const-expr   enable evaluation of constant expressions (e.g., Prefix + "suffix")
+  -ignore-calls      ignore string literals in calls to these functions (comma separated)
   -numbers           search also for duplicated numbers
   -min               minimum value, only works with -numbers
   -max               maximum value, only works with -numbers
@@ -55,6 +56,7 @@ Examples:
   goconst -numbers -min 60 -max 512 .
   goconst -min-occurrences 5 $(go list -m -f '{{.Dir}}')
   goconst -eval-const-expr -match-constant . # Matches constant expressions like Prefix + "suffix"
+  goconst -ignore-calls slog.Info,slog.Warn,fmt.Errorf ./... # Ignore strings in logging/error calls
 ```
 
 ### Development

--- a/api.go
+++ b/api.go
@@ -45,6 +45,9 @@ type Config struct {
 	FindDuplicates bool
 	// EvalConstExpressions enables evaluation of constant expressions like Prefix + "suffix"
 	EvalConstExpressions bool
+	// IgnoreFunctions is a list of function names whose string arguments should be ignored.
+	// Supports direct calls (e.g., "println") and one-level qualified calls (e.g., "slog.Info").
+	IgnoreFunctions []string
 }
 
 // NewWithIgnorePatterns creates a new instance of the parser with support for multiple ignore patterns.
@@ -107,6 +110,10 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 		cfg.MinOccurrences,
 		cfg.ExcludeTypes,
 	)
+
+	if len(cfg.IgnoreFunctions) > 0 {
+		p.SetIgnoreFunctions(cfg.IgnoreFunctions)
+	}
 
 	// Pre-allocate slice based on estimated result size
 	expectedIssues := len(files) * 5 // Assuming average of 5 issues per file

--- a/api_test.go
+++ b/api_test.go
@@ -913,6 +913,73 @@ func example() {
 	}
 }
 
+func TestRunWithConfig_IgnoreFunctions(t *testing.T) {
+	code := `package example
+import "log/slog"
+func example() {
+	slog.Info("msg")
+	slog.Info("msg")
+	println("other")
+	println("other")
+}`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  2,
+		IgnoreFunctions: []string{"slog.Info"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(issues) != 1 {
+		t.Fatalf("len(issues) = %d, want 1", len(issues))
+	}
+	if issues[0].Str != "other" {
+		t.Errorf("Issue.Str = %v, want other", issues[0].Str)
+	}
+}
+
+func TestRunWithConfig_IgnoreFunctions_Empty(t *testing.T) {
+	code := `package example
+func example() {
+	println("msg")
+	println("msg")
+}`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  2,
+		IgnoreFunctions: nil,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(issues) != 1 {
+		t.Fatalf("len(issues) = %d, want 1", len(issues))
+	}
+	if issues[0].Str != "msg" {
+		t.Errorf("Issue.Str = %v, want msg", issues[0].Str)
+	}
+}
+
 func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
 	cfg := &types.Config{
 		Error: func(err error) {},

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -28,6 +28,7 @@ Flags:
   -match-constant    look for existing constants matching the strings
   -find-duplicates   look for constants with identical values
   -eval-const-expr   enable evaluation of constant expressions (e.g., Prefix + "suffix")
+  -ignore-calls      ignore string literals in calls to these functions (comma separated)
   -numbers           search also for duplicated numbers
   -min               minimum value, only works with -numbers
   -max               maximum value, only works with -numbers
@@ -43,6 +44,7 @@ Examples:
   goconst -numbers -min 60 -max 512 .
   goconst -min-occurrences 5 $(go list -m -f '{{.Dir}}')
   goconst -eval-const-expr -match-constant . # Matches constant expressions like Prefix + "suffix"
+  goconst -ignore-calls slog.Info,slog.Warn,fmt.Errorf ./... # Ignore strings in logging/error calls
 `
 
 var (
@@ -60,6 +62,7 @@ var (
 	flagOutput         = flag.String("output", "text", "output formatting")
 	flagSetExitStatus  = flag.Bool("set-exit-status", false, "Set exit status to 2 if any issues are found")
 	flagGrouped        = flag.Bool("grouped", false, "print single line per match, only works with -output text")
+	flagIgnoreCalls    = flag.String("ignore-calls", "", "ignore string literals in calls to these functions (comma separated, e.g. slog.Info,fmt.Errorf)")
 )
 
 func main() {
@@ -118,6 +121,11 @@ func run(path string) (bool, error) {
 		*flagMinOccurrences,
 		map[goconst.Type]bool{},
 	)
+
+	if *flagIgnoreCalls != "" {
+		gco.SetIgnoreFunctions(parseCommaSeparatedValues(*flagIgnoreCalls))
+	}
+
 	strs, consts, err := gco.ParseTree()
 	if err != nil {
 		return false, err

--- a/compat/compat_test.go
+++ b/compat/compat_test.go
@@ -27,6 +27,7 @@ func TestGolangCICompatibility(t *testing.T) {
 		},
 		IgnoreTests:          false,
 		EvalConstExpressions: true,
+		IgnoreFunctions:      []string{"slog.Info", "fmt.Errorf"},
 	}
 
 	// Create a simple test file

--- a/parser.go
+++ b/parser.go
@@ -120,6 +120,7 @@ type Parser struct {
 	minLength, minOccurrences   int
 	numberMin, numberMax        int
 	excludeTypes                map[Type]bool
+	ignoreFunctions             map[string]struct{}
 	maxConcurrency              int
 	evalConstExpressions        bool // Whether to evaluate constant expressions
 
@@ -262,6 +263,22 @@ func (p *Parser) EnableBatchProcessing(batchSize int) {
 	if batchSize > 0 {
 		p.batchSize = batchSize
 	}
+}
+
+// SetIgnoreFunctions configures which function calls should have their string
+// arguments ignored. Supports direct calls (e.g., "println") and one-level
+// qualified calls (e.g., "slog.Info", "fmt.Errorf").
+func (p *Parser) SetIgnoreFunctions(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	m := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name != "" {
+			m[name] = struct{}{}
+		}
+	}
+	p.ignoreFunctions = m
 }
 
 // ParseTree will search the given path for occurrences that could be moved into constants.

--- a/parser.go
+++ b/parser.go
@@ -275,6 +275,7 @@ func (p *Parser) SetIgnoreFunctions(names []string) {
 	}
 	m := make(map[string]struct{}, len(names))
 	for _, name := range names {
+		name = strings.TrimSpace(name)
 		if name != "" {
 			m[name] = struct{}{}
 		}

--- a/parser.go
+++ b/parser.go
@@ -270,6 +270,7 @@ func (p *Parser) EnableBatchProcessing(batchSize int) {
 // qualified calls (e.g., "slog.Info", "fmt.Errorf").
 func (p *Parser) SetIgnoreFunctions(names []string) {
 	if len(names) == 0 {
+		p.ignoreFunctions = nil
 		return
 	}
 	m := make(map[string]struct{}, len(names))

--- a/visitor.go
+++ b/visitor.go
@@ -111,10 +111,12 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 
 	// fn("http://")
 	case *ast.CallExpr:
-		for _, item := range t.Args {
-			lit, ok := item.(*ast.BasicLit)
-			if ok && v.isSupported(lit.Kind) {
-				v.addString(lit.Value, lit.Pos(), Call)
+		if !v.shouldIgnoreCall(t) {
+			for _, item := range t.Args {
+				lit, ok := item.(*ast.BasicLit)
+				if ok && v.isSupported(lit.Kind) {
+					v.addString(lit.Value, lit.Pos(), Call)
+				}
 			}
 		}
 
@@ -146,6 +148,29 @@ func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr) {
 	if valueLit, ok := kv.Value.(*ast.BasicLit); ok && v.isSupported(valueLit.Kind) {
 		v.addString(valueLit.Value, valueLit.Pos(), CompositeLit)
 	}
+}
+
+// shouldIgnoreCall returns true if the call expression matches a function
+// name in the ignoreFunctions set. Supports direct calls (e.g., "println")
+// and one-level qualified calls (e.g., "slog.Info").
+func (v *treeVisitor) shouldIgnoreCall(call *ast.CallExpr) bool {
+	if len(v.p.ignoreFunctions) == 0 {
+		return false
+	}
+	var name string
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		name = fn.Name
+	case *ast.SelectorExpr:
+		if ident, ok := fn.X.(*ast.Ident); ok {
+			name = ident.Name + "." + fn.Sel.Name
+		}
+	}
+	if name == "" {
+		return false
+	}
+	_, found := v.p.ignoreFunctions[name]
+	return found
 }
 
 // addString adds a string in the map along with its position in the tree.

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -536,3 +536,108 @@ func TestTreeVisitor_AddString_NumberRange(t *testing.T) {
 		})
 	}
 }
+
+func TestTreeVisitor_ShouldIgnoreCall(t *testing.T) {
+	tests := []struct {
+		name            string
+		code            string
+		ignoreFunctions map[string]struct{}
+		expectStrings   int
+	}{
+		{
+			name: "slog.Info ignored",
+			code: `package example
+import "log/slog"
+func example() {
+	slog.Info("msg")
+	slog.Info("msg")
+}`,
+			ignoreFunctions: map[string]struct{}{"slog.Info": {}},
+			expectStrings:   0,
+		},
+		{
+			name: "println not ignored when slog.Info is",
+			code: `package example
+func example() {
+	println("msg")
+	println("msg")
+}`,
+			ignoreFunctions: map[string]struct{}{"slog.Info": {}},
+			expectStrings:   1,
+		},
+		{
+			name: "empty ignore list ignores nothing",
+			code: `package example
+import "log/slog"
+func example() {
+	slog.Info("msg")
+	slog.Info("msg")
+}`,
+			ignoreFunctions: nil,
+			expectStrings:   1,
+		},
+		{
+			name: "direct function call ignored",
+			code: `package example
+func example() {
+	println("msg")
+	println("msg")
+}`,
+			ignoreFunctions: map[string]struct{}{"println": {}},
+			expectStrings:   0,
+		},
+		{
+			name: "multiple ignored functions",
+			code: `package example
+import "fmt"
+func example() {
+	fmt.Println("keep")
+	fmt.Println("keep")
+	fmt.Errorf("skip")
+	fmt.Errorf("skip")
+}`,
+			ignoreFunctions: map[string]struct{}{"fmt.Errorf": {}},
+			expectStrings:   1, // only "keep" via fmt.Println
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "example.go", tt.code, 0)
+			if err != nil {
+				t.Fatalf("Failed to parse test code: %v", err)
+			}
+
+			p := &Parser{
+				minLength:        3,
+				minOccurrences:   2,
+				supportedTokens:  []token.Token{token.STRING},
+				excludeTypes:     map[Type]bool{},
+				ignoreFunctions:  tt.ignoreFunctions,
+				strs:             Strings{},
+				consts:           Constants{},
+				matchConstant:    false,
+				stringCount:      make(map[string]int),
+				stringMutex:      sync.RWMutex{},
+				stringCountMutex: sync.RWMutex{},
+			}
+
+			v := &treeVisitor{
+				p:           p,
+				fileSet:     fset,
+				packageName: "example",
+			}
+
+			ast.Walk(v, f)
+			p.ProcessResults()
+
+			if len(p.strs) != tt.expectStrings {
+				t.Errorf("expected %d strings, got %d", tt.expectStrings, len(p.strs))
+				for str, positions := range p.strs {
+					t.Logf("  found: %q (%d occurrences)", str, len(positions))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the ability to selectively ignore string literals in specific function calls, solving the use case where users want to flag hardcoded strings in most calls but not in structured logging or error formatting.

Closes #42

## Changes

- **`Config.IgnoreFunctions []string`** — new field, backward-compatible (zero value = no change)
- **`Parser.SetIgnoreFunctions()`** — setter method, no changes to `New()` or `NewWithIgnorePatterns()` signatures (preserves golangci-lint compatibility)
- **`shouldIgnoreCall()`** — extracts function name from `CallExpr.Fun`, supports:
  - Direct calls: `println("foo")` → matches `"println"`
  - Qualified calls: `slog.Info("msg")` → matches `"slog.Info"`
- **`-ignore-calls` CLI flag** — comma-separated, e.g., `-ignore-calls slog.Info,fmt.Errorf`
- **Zero overhead** when unused — empty-map fast path short-circuits before any AST inspection

## Design decisions

- **No signature changes** to exported constructors — avoids breaking golangci-lint and other callers
- **Exact match only** — no regex, covers the use case without performance/complexity cost
- **One level of selector depth** — `pkg.Func` supported, not chained `obj.Logger.Info`
- **`return v` not `return nil`** — still descends into child nodes so nested calls in args are checked

## Test plan

- [x] `go test ./... -v -count=1` — all pass (160+ tests)
- [x] `go test ./... -race -count=1` — no data races
- [x] Compat test updated with `IgnoreFunctions` field
- [x] 5 visitor-level test cases + 2 API-level test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `-ignore-calls` CLI flag to exclude string literals found within calls to specified functions (comma-separated list format).

* **Documentation**
  * Updated README with `-ignore-calls` flag usage details and command examples.

* **Tests**
  * Added comprehensive test coverage for the new function-call filtering capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->