### PR TITLE
fix(api): scope occurrence counts, constants, and duplicates by test/non-test

### DIFF
--- a/api.go
+++ b/api.go
@@ -12,6 +12,8 @@ import (
 // Issue represents a finding of duplicated strings, numbers, or constants.
 // Each Issue includes the position where it was found, how many times it occurs,
 // the string itself, and any matching constant name.
+// When both test and non-test files are analyzed, OccurrencesCount reflects
+// the count within the issue's scope (test or non-test) rather than the global total.
 type Issue struct {
 	Pos              token.Position
 	OccurrencesCount int
@@ -152,13 +154,14 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 				wg.Done()
 			}()
 
-			// Use empty interned strings for package/file names
-			// The visitor logic will set these appropriately
-			emptyStr := InternString("")
+			pkgName := ""
+			if f.Name != nil {
+				pkgName = f.Name.Name
+			}
 
 			ast.Walk(&treeVisitor{
 				fileSet:     fset,
-				packageName: emptyStr,
+				packageName: InternString(pkgName),
 				p:           p,
 				ignoreRegex: p.ignoreStringsRegex,
 				typeInfo:    typeInfo,
@@ -177,7 +180,8 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 	// Create a slice to hold the string keys
 	stringKeys := make([]string, 0, len(p.strs))
 
-	// Create an array of strings to sort for stable output
+	// Global count is a coarse prefilter; the reporting loop below
+	// re-applies minOccurrences per scope (test vs non-test).
 	for str := range p.strs {
 		if count := p.stringCount[str]; count >= p.minOccurrences {
 			stringKeys = append(stringKeys, str)
@@ -189,21 +193,51 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 	// Emit one issue per file where the string appears, so that
 	// path-based exclusion can independently filter each one without
 	// suppressing legitimate findings in other files.
+	// Occurrence counts are scoped: test-file issues report test-file
+	// counts and non-test issues report non-test counts, preventing
+	// test-file occurrences from inflating production-file reports.
 	for _, str := range stringKeys {
-		positions := p.strs[str]
+		// Copy positions so the sort does not mutate the map value
+		// under the read lock.
+		positions := append([]ExtendedPos(nil), p.strs[str]...)
 		if len(positions) == 0 {
 			continue
 		}
 
-		occurrences := p.stringCount[str]
+		sortPositions(positions)
 
-		var matchingConst string
-		if len(p.consts) > 0 {
-			p.constMutex.RLock()
-			if csts, ok := p.consts[str]; ok && len(csts) > 0 {
-				matchingConst = csts[0].Name
+		var nonTestCount, testCount int
+		for _, pos := range positions {
+			if strings.HasSuffix(pos.Filename, testSuffix) {
+				testCount++
+			} else {
+				nonTestCount++
 			}
+		}
+
+		// Resolve matching constants per scope so that non-test issues
+		// never reference test-only constants (which production code
+		// cannot use). Test issues may reference any constant.
+		// Only resolve when MatchWithConstants is enabled; FindDuplicates
+		// also populates p.consts but should not affect string issues.
+		var anyMatchingConst, nonTestMatchingConst string
+		if p.matchConstant {
+			p.constMutex.RLock()
+			raw := p.consts[str]
 			p.constMutex.RUnlock()
+
+			if len(raw) > 0 {
+				// Copy so the sort does not mutate the map value.
+				csts := append([]ConstType(nil), raw...)
+				sortConstants(csts)
+				anyMatchingConst = csts[0].Name
+				for _, cst := range csts {
+					if !strings.HasSuffix(cst.Filename, testSuffix) {
+						nonTestMatchingConst = cst.Name
+						break
+					}
+				}
+			}
 		}
 
 		seen := make(map[string]bool)
@@ -213,9 +247,25 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 			}
 			seen[pos.Filename] = true
 
+			isTest := strings.HasSuffix(pos.Filename, testSuffix)
+
+			scopeCount := nonTestCount
+			if isTest {
+				scopeCount = testCount
+			}
+
+			if scopeCount < p.minOccurrences {
+				continue
+			}
+
+			matchingConst := nonTestMatchingConst
+			if isTest && matchingConst == "" {
+				matchingConst = anyMatchingConst
+			}
+
 			issueBuffer = append(issueBuffer, Issue{
 				Pos:              pos.Position,
-				OccurrencesCount: occurrences,
+				OccurrencesCount: scopeCount,
 				Str:              str,
 				MatchingConst:    matchingConst,
 			})
@@ -225,36 +275,52 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 	p.stringCountMutex.RUnlock()
 	p.stringMutex.RUnlock()
 
-	// process duplicate constants
-	p.constMutex.RLock()
+	// Process duplicate constants only when explicitly requested.
+	// p.consts may also be populated by matchConstant for constant
+	// matching, but those extra entries should not trigger duplicate reports.
+	if p.findDuplicates {
+		p.constMutex.RLock()
 
-	// Create a new slice for const keys
-	stringKeys = make([]string, 0, len(p.consts))
+		stringKeys = make([]string, 0, len(p.consts))
 
-	// Create an array of strings and sort for stable output
-	for str := range p.consts {
-		if len(p.consts[str]) > 1 {
-			stringKeys = append(stringKeys, str)
+		for str := range p.consts {
+			if len(p.consts[str]) > 1 {
+				stringKeys = append(stringKeys, str)
+			}
 		}
-	}
 
-	sort.Strings(stringKeys)
+		sort.Strings(stringKeys)
 
-	// report an issue for every duplicated const
-	for _, str := range stringKeys {
-		positions := p.consts[str]
+		// Report an issue for every duplicated const within the same scope.
+		// Test and non-test constants are compared independently so that a
+		// test constant is never flagged as duplicate of a production one.
+		for _, str := range stringKeys {
+			allConsts := p.consts[str]
 
-		for i := 1; i < len(positions); i++ {
-			issueBuffer = append(issueBuffer, Issue{
-				Pos:            positions[i].Position,
-				Str:            str,
-				DuplicateConst: positions[0].Name,
-				DuplicatePos:   positions[0].Position,
-			})
+			var nonTestConsts, testConsts []ConstType
+			for _, cst := range allConsts {
+				if strings.HasSuffix(cst.Filename, testSuffix) {
+					testConsts = append(testConsts, cst)
+				} else {
+					nonTestConsts = append(nonTestConsts, cst)
+				}
+			}
+
+			for _, scopeConsts := range [][]ConstType{nonTestConsts, testConsts} {
+				sortConstants(scopeConsts)
+				for i := 1; i < len(scopeConsts); i++ {
+					issueBuffer = append(issueBuffer, Issue{
+						Pos:            scopeConsts[i].Position,
+						Str:            str,
+						DuplicateConst: scopeConsts[0].Name,
+						DuplicatePos:   scopeConsts[0].Position,
+					})
+				}
+			}
 		}
-	}
 
-	p.constMutex.RUnlock()
+		p.constMutex.RUnlock()
+	}
 
 	// Don't return the buffer to pool as the caller now owns it
 	return issueBuffer, nil
@@ -265,4 +331,26 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 // It returns a slice of Issue objects containing the findings.
 func Run(files []*ast.File, fset *token.FileSet, typeInfo *types.Info, cfg *Config) ([]Issue, error) {
 	return RunWithConfig(files, fset, typeInfo, cfg)
+}
+
+func lessPosition(a, b token.Position) bool {
+	if a.Filename != b.Filename {
+		return a.Filename < b.Filename
+	}
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	return a.Column < b.Column
+}
+
+func sortPositions(positions []ExtendedPos) {
+	sort.Slice(positions, func(i, j int) bool {
+		return lessPosition(positions[i].Position, positions[j].Position)
+	})
+}
+
+func sortConstants(consts []ConstType) {
+	sort.Slice(consts, func(i, j int) bool {
+		return lessPosition(consts[i].Position, consts[j].Position)
+	})
 }

--- a/api_test.go
+++ b/api_test.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"strings"
 	"testing"
 )
 
@@ -683,26 +684,21 @@ func testHelper() {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	if len(issues) != 2 {
-		t.Fatalf("len(issues) = %d, want 2", len(issues))
+	// Per-scope counting: "repeated" has 2 non-test occurrences and
+	// 1 test occurrence. Only the non-test scope meets MinOccurrences=2.
+	if len(issues) != 1 {
+		t.Fatalf("len(issues) = %d, want 1", len(issues))
 	}
 
-	files := make(map[string]bool)
-	for _, issue := range issues {
-		if issue.Str != "repeated" {
-			t.Errorf("Issue.Str = %v, want %v", issue.Str, "repeated")
-		}
-		if issue.OccurrencesCount != 3 {
-			t.Errorf("Issue.OccurrencesCount = %v, want 3", issue.OccurrencesCount)
-		}
-		files[issue.Pos.Filename] = true
+	issue := issues[0]
+	if issue.Str != "repeated" {
+		t.Errorf("Issue.Str = %v, want repeated", issue.Str)
 	}
-
-	if !files["example.go"] {
-		t.Errorf("Issue.Pos.Filename: missing example.go")
+	if issue.OccurrencesCount != 2 {
+		t.Errorf("Issue.OccurrencesCount = %v, want 2", issue.OccurrencesCount)
 	}
-	if !files["example_test.go"] {
-		t.Errorf("Issue.Pos.Filename: missing example_test.go")
+	if issue.Pos.Filename != "example.go" {
+		t.Errorf("Issue.Pos.Filename = %v, want example.go", issue.Pos.Filename)
 	}
 }
 
@@ -765,6 +761,551 @@ func testHelper() {
 	}
 	if issue.OccurrencesCount != 2 {
 		t.Errorf("Issue.OccurrencesCount = %v, want 2", issue.OccurrencesCount)
+	}
+}
+
+func TestIssue57_TestFileInflation(t *testing.T) {
+	code := `package example
+func boolFunc() {
+	_ = "false"
+}`
+	testCode := `package example
+func testBoolFunc() {
+	_ = "false"
+	_ = "false"
+	_ = "false"
+	_ = "false"
+	_ = "false"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "bool.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse bool.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "bool_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse bool_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  4,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// bool.go has 1 occurrence (below threshold of 4) — no issue.
+	// bool_test.go has 5 occurrences (meets threshold) — issue emitted.
+	if len(issues) != 1 {
+		t.Fatalf("len(issues) = %d, want 1", len(issues))
+	}
+
+	issue := issues[0]
+	if issue.Pos.Filename != "bool_test.go" {
+		t.Errorf("Issue.Pos.Filename = %v, want bool_test.go", issue.Pos.Filename)
+	}
+	if issue.OccurrencesCount != 5 {
+		t.Errorf("Issue.OccurrencesCount = %v, want 5", issue.OccurrencesCount)
+	}
+	if issue.Str != "false" {
+		t.Errorf("Issue.Str = %v, want false", issue.Str)
+	}
+}
+
+func TestIssue57_PerScopeThreshold(t *testing.T) {
+	code := `package example
+func prodFunc() {
+	_ = "shared"
+	_ = "shared"
+}`
+	testCode := `package example
+func testFunc() {
+	_ = "shared"
+	_ = "shared"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "prod.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "prod_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  3,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Global count is 4 (survives ProcessResults with minOccurrences=3),
+	// but nonTestCount=2 < 3 and testCount=2 < 3, so no issues emitted.
+	if len(issues) != 0 {
+		t.Errorf("len(issues) = %d, want 0", len(issues))
+		for _, issue := range issues {
+			t.Logf("Unexpected issue: %q at %s with %d occurrences",
+				issue.Str, issue.Pos.Filename, issue.OccurrencesCount)
+		}
+	}
+}
+
+func TestIssue57_BothScopesMeetThreshold(t *testing.T) {
+	code := `package example
+func prodFunc() {
+	_ = "common"
+	_ = "common"
+	_ = "common"
+}`
+	testCode := `package example
+func testFunc() {
+	_ = "common"
+	_ = "common"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "lib.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "lib_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  2,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Both scopes meet threshold: 2 issues with per-scope counts.
+	if len(issues) != 2 {
+		t.Fatalf("len(issues) = %d, want 2", len(issues))
+	}
+
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		if issue.Str != "common" {
+			t.Errorf("Issue.Str = %v, want common", issue.Str)
+		}
+		counts[issue.Pos.Filename] = issue.OccurrencesCount
+	}
+
+	if counts["lib.go"] != 3 {
+		t.Errorf("lib.go OccurrencesCount = %v, want 3", counts["lib.go"])
+	}
+	if counts["lib_test.go"] != 2 {
+		t.Errorf("lib_test.go OccurrencesCount = %v, want 2", counts["lib_test.go"])
+	}
+}
+
+func TestMatchingConst_CrossScopeLeakage(t *testing.T) {
+	// Reproduces cross-scope leakage: a constant declared only in a test
+	// file should not be suggested as MatchingConst for a production issue,
+	// because production code cannot reference test-only constants.
+	code := `package example
+func prodFunc() {
+	_ = "magic-value"
+	_ = "magic-value"
+}`
+	testCode := `package example
+const TestMagic = "magic-value"
+func testFunc() {
+	_ = "magic-value"
+	_ = "magic-value"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "prod.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "prod_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		MatchWithConstants: true,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Both scopes meet threshold → 2 issues.
+	if len(issues) != 2 {
+		t.Fatalf("len(issues) = %d, want 2", len(issues))
+	}
+
+	for _, issue := range issues {
+		if issue.Pos.Filename == "prod.go" && issue.MatchingConst != "" {
+			// BUG: prod.go issue references TestMagic which is defined
+			// only in prod_test.go — production code cannot use it.
+			t.Errorf("prod.go issue has MatchingConst=%q from test file; "+
+				"production issues should not reference test-only constants",
+				issue.MatchingConst)
+		}
+	}
+}
+
+func TestFindDuplicates_CrossScopeLeakage(t *testing.T) {
+	// Reproduces cross-scope leakage for FindDuplicates: a constant
+	// in a test file should not be reported as a duplicate of a
+	// production constant (or vice versa), because they live in
+	// different scopes.
+	code := `package example
+const ProdConst = "shared-value"
+`
+	testCode := `package example
+const TestConst = "shared-value"
+`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "prod.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "prod_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  1,
+		FindDuplicates:  true,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for _, issue := range issues {
+		if issue.DuplicateConst == "" {
+			continue
+		}
+		issueIsTest := strings.HasSuffix(issue.Pos.Filename, "_test.go")
+		dupIsTest := strings.HasSuffix(issue.DuplicatePos.Filename, "_test.go")
+		if issueIsTest != dupIsTest {
+			// BUG: cross-scope duplicate reported — a test constant
+			// is flagged as duplicate of a production constant.
+			t.Errorf("cross-scope duplicate: %s (%s) flagged as duplicate of %s (%s)",
+				issue.Str, issue.Pos.Filename,
+				issue.DuplicateConst, issue.DuplicatePos.Filename)
+		}
+	}
+}
+
+func TestMatchingConst_FindDuplicatesOnly(t *testing.T) {
+	// When FindDuplicates is enabled but MatchWithConstants is not,
+	// p.consts gets populated for duplicate detection. The reporting
+	// loop should NOT set MatchingConst on string issues in this case.
+	code := `package example
+const MyConst = "some-value"
+func example() {
+	_ = "some-value"
+	_ = "some-value"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, &Config{
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		FindDuplicates:     true,
+		MatchWithConstants: false,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for _, issue := range issues {
+		if issue.DuplicateConst != "" {
+			continue // skip duplicate-const issues
+		}
+		if issue.MatchingConst != "" {
+			// BUG: MatchingConst is set even though MatchWithConstants=false,
+			// because FindDuplicates also populates p.consts.
+			t.Errorf("MatchingConst = %q for string %q, want empty "+
+				"(MatchWithConstants is false)", issue.MatchingConst, issue.Str)
+		}
+	}
+}
+
+func TestNondeterministicOutput(t *testing.T) {
+	// With concurrent visitors, positions are appended in arbitrary
+	// goroutine order. This can make issue positions and the selected
+	// MatchingConst vary between runs. Verify output is deterministic.
+	sources := map[string]string{
+		"a.go": `package example
+func a() { _ = "ndet"; _ = "ndet" }`,
+		"b.go": `package example
+func b() { _ = "ndet"; _ = "ndet" }`,
+		"c.go": `package example
+func c() { _ = "ndet"; _ = "ndet" }`,
+		"d.go": `package example
+func d() { _ = "ndet"; _ = "ndet" }`,
+		"e.go": `package example
+func e() { _ = "ndet"; _ = "ndet" }`,
+	}
+
+	// Run 10 times and collect the issue ordering each time.
+	var firstRun []string
+	for attempt := 0; attempt < 10; attempt++ {
+		fset := token.NewFileSet()
+		var files []*ast.File
+		// Parse in deterministic order.
+		for _, name := range []string{"a.go", "b.go", "c.go", "d.go", "e.go"} {
+			f, err := parser.ParseFile(fset, name, sources[name], 0)
+			if err != nil {
+				t.Fatalf("Failed to parse %s: %v", name, err)
+			}
+			files = append(files, f)
+		}
+
+		chkr, info := checker(fset)
+		_ = chkr.Files(files)
+
+		issues, err := Run(files, fset, info, &Config{
+			MinStringLength: 3,
+			MinOccurrences:  2,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+
+		var order []string
+		for _, issue := range issues {
+			order = append(order, fmt.Sprintf("%s:%d", issue.Pos.Filename, issue.Pos.Line))
+		}
+
+		if attempt == 0 {
+			firstRun = order
+		} else {
+			if len(order) != len(firstRun) {
+				t.Fatalf("attempt %d: got %d issues, first run had %d", attempt, len(order), len(firstRun))
+			}
+			for i := range order {
+				if order[i] != firstRun[i] {
+					// BUG: issue ordering varies between runs due to
+					// nondeterministic concurrent visitor appends.
+					t.Errorf("attempt %d: issue[%d] = %s, first run had %s",
+						attempt, i, order[i], firstRun[i])
+				}
+			}
+		}
+	}
+}
+
+func TestMatchWithConstantsAndFindDuplicates(t *testing.T) {
+	// Both MatchWithConstants and FindDuplicates enabled — a realistic
+	// golangci-lint config. Verify matching constant resolution and
+	// duplicate detection work correctly together.
+	code := `package example
+const ProdConst = "shared"
+func example() {
+	_ = "shared"
+	_ = "shared"
+}`
+	code2 := `package example
+const ProdConst2 = "shared"
+`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "a.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse a.go: %v", err)
+	}
+	f2, err := parser.ParseFile(fset, "b.go", code2, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse b.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, f2})
+
+	issues, err := Run([]*ast.File{f, f2}, fset, info, &Config{
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		MatchWithConstants: true,
+		FindDuplicates:     true,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var stringIssues, dupIssues []Issue
+	for _, issue := range issues {
+		if issue.DuplicateConst != "" {
+			dupIssues = append(dupIssues, issue)
+		} else {
+			stringIssues = append(stringIssues, issue)
+		}
+	}
+
+	// String issues should have MatchingConst set.
+	for _, issue := range stringIssues {
+		if issue.Str != "shared" {
+			continue
+		}
+		if issue.MatchingConst == "" {
+			t.Errorf("string issue at %s missing MatchingConst", issue.Pos.Filename)
+		}
+	}
+
+	// Duplicate const issue: ProdConst2 is a duplicate of ProdConst
+	// (or vice versa, depending on position sort order).
+	if len(dupIssues) != 1 {
+		t.Fatalf("len(dupIssues) = %d, want 1", len(dupIssues))
+	}
+	if dupIssues[0].DuplicateConst == "" {
+		t.Error("duplicate issue missing DuplicateConst")
+	}
+}
+
+func TestTestOnlyString(t *testing.T) {
+	// String appears only in test files with IgnoreTests=false.
+	// Should produce a test-file issue but no production issue.
+	code := `package example
+func prodFunc() {
+	_ = "other"
+}`
+	testCode := `package example
+func testFunc() {
+	_ = "testonly"
+	_ = "testonly"
+	_ = "testonly"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "prod.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "prod_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse prod_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength: 3,
+		MinOccurrences:  2,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for _, issue := range issues {
+		if issue.Str != "testonly" {
+			continue
+		}
+		if issue.Pos.Filename != "prod_test.go" {
+			t.Errorf("testonly issue at %s, want prod_test.go", issue.Pos.Filename)
+		}
+		if issue.OccurrencesCount != 3 {
+			t.Errorf("testonly OccurrencesCount = %d, want 3", issue.OccurrencesCount)
+		}
+	}
+
+	// Verify no prod.go issue for "testonly" (it doesn't appear there).
+	for _, issue := range issues {
+		if issue.Str == "testonly" && issue.Pos.Filename == "prod.go" {
+			t.Error("unexpected prod.go issue for test-only string")
+		}
+	}
+}
+
+func TestMatchingConst_CrossScopePreference(t *testing.T) {
+	// When constants exist in both scopes, non-test issues should use
+	// the non-test constant. Test issues should prefer the non-test
+	// constant but fall back to test constants.
+	code := `package example
+const ProdConst = "val"
+func prodFunc() {
+	_ = "val"
+	_ = "val"
+}`
+	testCode := `package example
+const TestConst = "val"
+func testFunc() {
+	_ = "val"
+	_ = "val"
+}`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "lib.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "lib_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f, fTest})
+
+	issues, err := Run([]*ast.File{f, fTest}, fset, info, &Config{
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		MatchWithConstants: true,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for _, issue := range issues {
+		if issue.Str != "val" {
+			continue
+		}
+		switch issue.Pos.Filename {
+		case "lib.go":
+			if issue.MatchingConst != "ProdConst" {
+				t.Errorf("lib.go MatchingConst = %q, want ProdConst",
+					issue.MatchingConst)
+			}
+		case "lib_test.go":
+			// Test issue should prefer non-test constant (ProdConst)
+			// since test code can reference production constants.
+			if issue.MatchingConst != "ProdConst" {
+				t.Errorf("lib_test.go MatchingConst = %q, want ProdConst",
+					issue.MatchingConst)
+			}
+		}
 	}
 }
 

--- a/visitor.go
+++ b/visitor.go
@@ -285,8 +285,10 @@ func (v *treeVisitor) addConst(name string, val string, pos token.Pos) {
 	v.p.constMutex.Lock()
 	defer v.p.constMutex.Unlock()
 
-	// track this const if this is a new const, or if we are searching for duplicate consts
-	if _, ok := v.p.consts[internedVal]; !ok || v.p.findDuplicates {
+	// Collect the constant when it is the first with this value, when
+	// duplicate detection needs all of them, or when constant matching
+	// needs all of them to pick the best per scope.
+	if _, ok := v.p.consts[internedVal]; !ok || v.p.findDuplicates || v.p.matchConstant {
 		v.p.consts[internedVal] = append(v.p.consts[internedVal], ConstType{
 			Name:        internedName,
 			packageName: internedPkg,


### PR DESCRIPTION
Fixes #57

When golangci-lint passes both production and test files to `RunWithConfig`, occurrence counts were inflated by test-file occurrences, causing false positives after path-based exclusion.

## Changes

- **Per-scope occurrence counting**: test and non-test files counted separately for both threshold checks and `OccurrencesCount`
- **MatchingConst scoped**: non-test issues only reference non-test constants (production code can't use test-only constants)
- **FindDuplicates scoped**: duplicates only reported within same scope (test vs non-test)
- **MatchingConst gated** on `MatchWithConstants` config flag (FindDuplicates no longer leaks into string issues)
- **Deterministic output**: positions and constants sorted by filename/line/column before reporting
- **Collect all constants** when `MatchWithConstants` is enabled so cross-scope constants aren't lost
- **Gate duplicate reporting** on `FindDuplicates` flag
- **Copy slices before sorting** under RLock to respect lock contract
- **Set packageName** from AST in RunWithConfig path