### PR TITLE
test(compat): rewrite golangci-lint integration tests to simulate full pipeline

### DIFF
--- a/compat/compat_integration_test.go
+++ b/compat/compat_integration_test.go
@@ -4,164 +4,137 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"go/types"
 	"testing"
 
-	goconstAPI "github.com/jgautheron/goconst"
+	goconst "github.com/jgautheron/goconst"
 )
 
-func TestGolangCIIntegration(t *testing.T) {
-	const testCode = `package example
-
-const ExistingConst = "test-const"
-
-func example() {
-	// This should be detected as it matches ExistingConst
-	str1 := "test-const"
-	str2 := "test-const"
-
-	// This should be detected as a duplicate without matching constant
-	dup1 := "duplicate"
-	dup2 := "duplicate"
-
-	// This should be ignored as it's in a function call
-	println("ignored-in-call")
-	println("ignored-in-call")
-
-	// This should be ignored as it's too short
-	x := "a"
-	y := "a"
-
-	// This should be ignored due to IgnoreStrings
-	skip := "test-ignore"
-	skip2 := "test-ignore"
-}
-`
-
-	// Parse the test code
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "example.go", testCode, 0)
-	if err != nil {
-		t.Fatalf("Failed to parse test code: %v", err)
-	}
-
-	// Configure exactly as golangci-lint does
-	cfg := &goconstAPI.Config{
-		IgnoreStrings:      []string{"test-ignore"},
-		MatchWithConstants: true,
-		MinStringLength:    3,
-		MinOccurrences:     2,
-		ParseNumbers:       false,
-		ExcludeTypes: map[goconstAPI.Type]bool{
-			goconstAPI.Call: true,
-		},
-		IgnoreTests: false,
-	}
-
-	chkr, info := checker(fset)
-	_ = chkr.Files([]*ast.File{f})
-
-	// Run the analysis
-	issues, err := goconstAPI.Run([]*ast.File{f}, fset, info, cfg)
-	if err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
-
-	// Verify we get exactly the issues we expect
-	expectedIssues := map[string]struct {
-		count         int
-		matchingConst string
-	}{
-		"test-const": {2, "ExistingConst"},
-		"duplicate":  {2, ""},
-	}
-
-	if len(issues) != len(expectedIssues) {
-		t.Errorf("Got %d issues, want %d", len(issues), len(expectedIssues))
-		for _, issue := range issues {
-			t.Logf("Found issue: %q matches constant %q with %d occurrences",
-				issue.Str, issue.MatchingConst, issue.OccurrencesCount)
-		}
-	}
-
-	for _, issue := range issues {
-		expected, ok := expectedIssues[issue.Str]
-		if !ok {
-			t.Errorf("Unexpected issue found: %q", issue.Str)
-			continue
-		}
-
-		if issue.OccurrencesCount != expected.count {
-			t.Errorf("String %q: got %d occurrences, want %d",
-				issue.Str, issue.OccurrencesCount, expected.count)
-		}
-
-		if issue.MatchingConst != expected.matchingConst {
-			t.Errorf("String %q: got matching const %q, want %q",
-				issue.Str, issue.MatchingConst, expected.matchingConst)
-		}
-	}
-}
-
-func TestMultipleIgnorePatternsIntegration(t *testing.T) {
-	const testCode = `package example
+// TestGolangCILintConfig_IgnoreStrings verifies that multiple ignore
+// string patterns work when configured the way golangci-lint does.
+func TestGolangCILintConfig_IgnoreStrings(t *testing.T) {
+	const code = `package example
 
 func example() {
-	// These should be ignored by different patterns
 	foo1 := "foobar"
 	foo2 := "foobar"
-	
+
 	bar1 := "barbaz"
 	bar2 := "barbaz"
-	
-	// These should be detected
+
 	test1 := "example"
 	test2 := "example"
 }
 `
 
-	// Parse the test code
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "example.go", testCode, 0)
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
 	if err != nil {
-		t.Fatalf("Failed to parse test code: %v", err)
-	}
-
-	// Configure with multiple ignore patterns
-	cfg := &goconstAPI.Config{
-		IgnoreStrings:   []string{"foo.+", "bar.+"}, // Multiple patterns
-		MinStringLength: 3,
-		MinOccurrences:  2,
+		t.Fatalf("Failed to parse: %v", err)
 	}
 
 	chkr, info := checker(fset)
 	_ = chkr.Files([]*ast.File{f})
 
-	// Run the analysis
-	issues, err := goconstAPI.Run([]*ast.File{f}, fset, info, cfg)
+	cfg := &goconst.Config{
+		IgnoreStrings:   []string{"foo.+", "bar.+"},
+		MinStringLength: 3,
+		MinOccurrences:  2,
+	}
+
+	issues, err := goconst.Run([]*ast.File{f}, fset, info, cfg)
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	// Verify that "foobar" and "barbaz" are ignored but "example" is found
 	if len(issues) != 1 {
-		t.Errorf("Expected 1 issue, got %d", len(issues))
-		for _, issue := range issues {
-			t.Logf("Found issue: %q with %d occurrences",
-				issue.Str, issue.OccurrencesCount)
-		}
-		return
+		t.Fatalf("expected 1 issue, got %d", len(issues))
 	}
-
-	// The only issue should be "example"
 	if issues[0].Str != "example" {
-		t.Errorf("Expected to find 'example', got %q", issues[0].Str)
+		t.Errorf("expected 'example', got %q", issues[0].Str)
 	}
 }
 
-// TestConstExpressionCompatibility verifies support for constant expressions
-func TestConstExpressionCompatibility(t *testing.T) {
-	const testCode = `package example
+// TestGolangCILintConfig_ExcludeCallAndIgnore verifies combined config:
+// ExcludeTypes + IgnoreStrings + MatchWithConstants, which is the
+// typical golangci-lint setup.
+func TestGolangCILintConfig_ExcludeCallAndIgnore(t *testing.T) {
+	const code = `package example
+
+const ExistingConst = "test-const"
+
+func example() {
+	str1 := "test-const"
+	str2 := "test-const"
+
+	dup1 := "duplicate"
+	dup2 := "duplicate"
+
+	println("ignored-in-call")
+	println("ignored-in-call")
+
+	x := "a"
+	y := "a"
+
+	skip := "test-ignore"
+	skip2 := "test-ignore"
+}
+`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	cfg := &goconst.Config{
+		IgnoreStrings:      []string{"test-ignore"},
+		MatchWithConstants: true,
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		ExcludeTypes: map[goconst.Type]bool{
+			goconst.Call: true,
+		},
+	}
+
+	issues, err := goconst.Run([]*ast.File{f}, fset, info, cfg)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	expected := map[string]string{
+		"test-const": "ExistingConst",
+		"duplicate":  "",
+	}
+
+	if len(issues) != len(expected) {
+		t.Errorf("got %d issues, want %d", len(issues), len(expected))
+		for _, issue := range issues {
+			t.Logf("  %q (const=%q, count=%d)", issue.Str, issue.MatchingConst, issue.OccurrencesCount)
+		}
+	}
+
+	for _, issue := range issues {
+		wantConst, ok := expected[issue.Str]
+		if !ok {
+			t.Errorf("unexpected issue for %q", issue.Str)
+			continue
+		}
+		if issue.MatchingConst != wantConst {
+			t.Errorf("%q: MatchingConst = %q, want %q", issue.Str, issue.MatchingConst, wantConst)
+		}
+		if issue.OccurrencesCount != 2 {
+			t.Errorf("%q: OccurrencesCount = %d, want 2", issue.Str, issue.OccurrencesCount)
+		}
+	}
+}
+
+// TestGolangCILintConfig_ConstExpressions verifies that constant
+// expression evaluation works through the golangci-lint API path.
+func TestGolangCILintConfig_ConstExpressions(t *testing.T) {
+	const code = `package example
 
 const (
 	Prefix = "domain.com/"
@@ -170,82 +143,52 @@ const (
 )
 
 func example() {
-	// This should match the constant expression
 	path1 := "domain.com/api"
 	path2 := "domain.com/api"
-	
-	// This should also match
+
 	web1 := "domain.com/web"
 	web2 := "domain.com/web"
 }
 `
 
-	// Parse the test code
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "example.go", testCode, 0)
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
 	if err != nil {
-		t.Fatalf("Failed to parse test code: %v", err)
+		t.Fatalf("Failed to parse: %v", err)
 	}
 
-	// Configure with constant expression evaluation enabled
-	cfg := &goconstAPI.Config{
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	cfg := &goconst.Config{
 		MinStringLength:      3,
 		MinOccurrences:       2,
 		MatchWithConstants:   true,
 		EvalConstExpressions: true,
 	}
 
-	chkr, info := checker(fset)
-	_ = chkr.Files([]*ast.File{f})
-
-	// Run the analysis
-	issues, err := goconstAPI.Run([]*ast.File{f}, fset, info, cfg)
+	issues, err := goconst.Run([]*ast.File{f}, fset, info, cfg)
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	// Verify we get exactly the issues we expect
-	expectedIssues := map[string]struct {
-		count         int
-		matchingConst string
-	}{
-		"domain.com/api": {2, "API"},
-		"domain.com/web": {2, "Web"},
+	expected := map[string]string{
+		"domain.com/api": "API",
+		"domain.com/web": "Web",
 	}
 
-	if len(issues) != len(expectedIssues) {
-		t.Errorf("Got %d issues, want %d", len(issues), len(expectedIssues))
-		for _, issue := range issues {
-			t.Logf("Found issue: %q matches constant %q with %d occurrences",
-				issue.Str, issue.MatchingConst, issue.OccurrencesCount)
-		}
+	if len(issues) != len(expected) {
+		t.Errorf("got %d issues, want %d", len(issues), len(expected))
 	}
 
 	for _, issue := range issues {
-		expected, ok := expectedIssues[issue.Str]
+		wantConst, ok := expected[issue.Str]
 		if !ok {
-			t.Errorf("Unexpected issue found: %q", issue.Str)
+			t.Errorf("unexpected issue for %q", issue.Str)
 			continue
 		}
-
-		if issue.OccurrencesCount != expected.count {
-			t.Errorf("String %q: got %d occurrences, want %d",
-				issue.Str, issue.OccurrencesCount, expected.count)
-		}
-
-		if issue.MatchingConst != expected.matchingConst {
-			t.Errorf("String %q: got matching const %q, want %q",
-				issue.Str, issue.MatchingConst, expected.matchingConst)
+		if issue.MatchingConst != wantConst {
+			t.Errorf("%q: MatchingConst = %q, want %q", issue.Str, issue.MatchingConst, wantConst)
 		}
 	}
-}
-
-func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
-	cfg := &types.Config{
-		Error: func(err error) {},
-	}
-	info := &types.Info{
-		Types: make(map[ast.Expr]types.TypeAndValue),
-	}
-	return types.NewChecker(cfg, fset, types.NewPackage("", "example"), info), info
 }

--- a/compat/compat_test.go
+++ b/compat/compat_test.go
@@ -1,85 +1,296 @@
 package compat
 
 import (
+	"go/ast"
+	"go/parser"
 	"go/token"
 	"go/types"
+	"regexp"
 	"testing"
 
-	goconstAPI "github.com/jgautheron/goconst"
+	goconst "github.com/jgautheron/goconst"
 )
 
-// TestGolangCICompatibility verifies that our API remains compatible
-// with how golangci-lint uses it
-func TestGolangCICompatibility(t *testing.T) {
-	// This test mimics how golangci-lint configures and uses goconst
-	// See: https://github.com/golangci/golangci-lint/blob/main/pkg/golinters/goconst/goconst.go
-
-	cfg := goconstAPI.Config{
-		IgnoreStrings:      []string{"test"},
-		MatchWithConstants: true,
-		MinStringLength:    3,
-		MinOccurrences:     2,
-		ParseNumbers:       true,
-		NumberMin:          100,
-		NumberMax:          1000,
-		ExcludeTypes: map[goconstAPI.Type]bool{
-			goconstAPI.Call: true,
-		},
-		IgnoreTests:          false,
-		EvalConstExpressions: true,
-		IgnoreFunctions:      []string{"slog.Info", "fmt.Errorf"},
+// filterIssuesByPath simulates golangci-lint's path-based exclusion.
+// golangci-lint calls goconst.Run() with ALL files, then filters
+// the returned issues by path patterns from its exclusions config.
+func filterIssuesByPath(issues []goconst.Issue, excludePatterns []string) []goconst.Issue {
+	var filtered []goconst.Issue
+	for _, issue := range issues {
+		excluded := false
+		for _, pattern := range excludePatterns {
+			if matched, _ := regexp.MatchString(pattern, issue.Pos.Filename); matched {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			filtered = append(filtered, issue)
+		}
 	}
-
-	// Create a simple test file
-	fset := token.NewFileSet()
-
-	info := &types.Info{}
-
-	// Verify that the API call signature matches what golangci-lint expects
-	_, err := goconstAPI.Run(nil, fset, info, &cfg)
-	if err != nil {
-		// We expect an error since we passed nil files
-		// but the important part is that the function signature matches
-		t.Log("Expected error from nil files:", err)
-	}
-
-	// Verify that the Issue struct has all fields golangci-lint expects
-	issue := goconstAPI.Issue{
-		Pos:              token.Position{},
-		OccurrencesCount: 2,
-		Str:              "test",
-		MatchingConst:    "TEST",
-	}
-
-	// Verify we can access all fields golangci-lint uses
-	_ = issue.Pos
-	_ = issue.OccurrencesCount
-	_ = issue.Str
-	_ = issue.MatchingConst
+	return filtered
 }
 
-// TestMultipleIgnorePatterns verifies that multiple ignore patterns work correctly
-func TestMultipleIgnorePatterns(t *testing.T) {
-	// Test configuration with multiple ignore patterns
-	cfg := goconstAPI.Config{
-		IgnoreStrings:   []string{"foo.+", "bar.+", "test"},
+// TestGolangCILintPipeline_ExcludeTests simulates the full golangci-lint
+// pipeline for the most common case: test files excluded via path rules.
+//
+// This is the scenario from issue #57 — golangci-lint passes all files
+// to goconst, then filters out _test.go issues afterward.
+func TestGolangCILintPipeline_ExcludeTests(t *testing.T) {
+	prodCode := `package nullable
+const FalseStr = "false"
+func ParseBool(s string) bool {
+	switch s {
+	case "", "true", "false":
+		return true
+	}
+	return false
+}`
+	testCode := `package nullable
+func TestParseBool() {
+	_ = "false"
+	_ = "false"
+	_ = "false"
+	_ = "false"
+	_ = "false"
+}`
+
+	fset := token.NewFileSet()
+	fProd, err := parser.ParseFile(fset, "bool.go", prodCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse bool.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "bool_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse bool_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{fProd, fTest})
+
+	// golangci-lint config: goconst with min-occurrences=4, Call excluded.
+	// IgnoreTests is false — golangci-lint handles exclusion at its level.
+	cfg := &goconst.Config{
+		MinStringLength:    3,
+		MinOccurrences:     4,
+		MatchWithConstants: true,
+		ExcludeTypes: map[goconst.Type]bool{
+			goconst.Call: true,
+		},
+		IgnoreTests: false,
+	}
+
+	// Step 1: golangci-lint calls goconst with ALL files
+	allIssues, err := goconst.Run([]*ast.File{fProd, fTest}, fset, info, cfg)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Step 2: golangci-lint applies path exclusion for test files
+	//   exclusions:
+	//     rules:
+	//       - path: _test\.go
+	//         linters: [goconst]
+	surviving := filterIssuesByPath(allIssues, []string{`_test\.go`})
+
+	// After filtering, bool.go should NOT be flagged.
+	// "false" appears only 1x in production code (case clause),
+	// which is below min-occurrences=4.
+	for _, issue := range surviving {
+		if issue.Str == "false" {
+			t.Errorf("false positive after path exclusion: %s:%d has %q with %d occurrences",
+				issue.Pos.Filename, issue.Pos.Line, issue.Str, issue.OccurrencesCount)
+		}
+	}
+}
+
+// TestGolangCILintPipeline_ExcludeTests_MatchingConst verifies that
+// after path-based exclusion, surviving issues don't reference constants
+// that only exist in test files.
+func TestGolangCILintPipeline_ExcludeTests_MatchingConst(t *testing.T) {
+	prodCode := `package example
+func prod() {
+	_ = "magic"
+	_ = "magic"
+}`
+	testCode := `package example
+const TestMagic = "magic"
+func testHelper() {
+	_ = "magic"
+	_ = "magic"
+}`
+
+	fset := token.NewFileSet()
+	fProd, err := parser.ParseFile(fset, "lib.go", prodCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "lib_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{fProd, fTest})
+
+	cfg := &goconst.Config{
+		MinStringLength:    3,
+		MinOccurrences:     2,
+		MatchWithConstants: true,
+		ExcludeTypes: map[goconst.Type]bool{
+			goconst.Call: true,
+		},
+	}
+
+	allIssues, err := goconst.Run([]*ast.File{fProd, fTest}, fset, info, cfg)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	surviving := filterIssuesByPath(allIssues, []string{`_test\.go`})
+
+	if len(surviving) != 1 {
+		t.Fatalf("expected 1 surviving issue, got %d", len(surviving))
+	}
+
+	issue := surviving[0]
+	if issue.Pos.Filename != "lib.go" {
+		t.Errorf("expected issue in lib.go, got %s", issue.Pos.Filename)
+	}
+	if issue.OccurrencesCount != 2 {
+		t.Errorf("OccurrencesCount = %d, want 2", issue.OccurrencesCount)
+	}
+	// The matching constant should NOT reference TestMagic from the test file.
+	if issue.MatchingConst == "TestMagic" {
+		t.Errorf("MatchingConst = %q — production issue references test-only constant",
+			issue.MatchingConst)
+	}
+}
+
+// TestGolangCILintPipeline_NoExclusion verifies the baseline: when
+// golangci-lint does NOT exclude test files, both scopes are reported
+// with their own accurate counts.
+func TestGolangCILintPipeline_NoExclusion(t *testing.T) {
+	prodCode := `package example
+func prod() {
+	_ = "shared"
+	_ = "shared"
+	_ = "shared"
+}`
+	testCode := `package example
+func testHelper() {
+	_ = "shared"
+	_ = "shared"
+}`
+
+	fset := token.NewFileSet()
+	fProd, err := parser.ParseFile(fset, "lib.go", prodCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "lib_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse lib_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{fProd, fTest})
+
+	cfg := &goconst.Config{
 		MinStringLength: 3,
 		MinOccurrences:  2,
+		ExcludeTypes: map[goconst.Type]bool{
+			goconst.Call: true,
+		},
 	}
 
-	// Create a simple test file
-	fset := token.NewFileSet()
-
-	info := &types.Info{}
-
-	// We just want to verify that multiple patterns are accepted
-	_, err := goconstAPI.Run(nil, fset, info, &cfg)
+	issues, err := goconst.Run([]*ast.File{fProd, fTest}, fset, info, cfg)
 	if err != nil {
-		// We expect an error since we passed nil files
-		// but the important part is that multiple patterns are accepted
-		t.Log("Expected error from nil files:", err)
+		t.Fatalf("Run() error = %v", err)
 	}
 
-	// This tests the construction and acceptance of the config
-	// Actual pattern matching is tested in integration tests
+	// No exclusion: both files should have issues with per-scope counts.
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		if issue.Str == "shared" {
+			counts[issue.Pos.Filename] = issue.OccurrencesCount
+		}
+	}
+
+	if counts["lib.go"] != 3 {
+		t.Errorf("lib.go OccurrencesCount = %d, want 3", counts["lib.go"])
+	}
+	if counts["lib_test.go"] != 2 {
+		t.Errorf("lib_test.go OccurrencesCount = %d, want 2", counts["lib_test.go"])
+	}
+}
+
+// TestGolangCILintPipeline_FindDuplicates verifies that duplicate
+// constant detection works correctly through the golangci-lint pipeline,
+// including path-based exclusion of test files.
+func TestGolangCILintPipeline_FindDuplicates(t *testing.T) {
+	prodCode := `package example
+const ProdConst1 = "dup-val"
+const ProdConst2 = "dup-val"
+`
+	testCode := `package example
+const TestConst = "dup-val"
+`
+
+	fset := token.NewFileSet()
+	fProd, err := parser.ParseFile(fset, "consts.go", prodCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse consts.go: %v", err)
+	}
+	fTest, err := parser.ParseFile(fset, "consts_test.go", testCode, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse consts_test.go: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{fProd, fTest})
+
+	cfg := &goconst.Config{
+		MinStringLength: 3,
+		MinOccurrences:  1,
+		FindDuplicates:  true,
+	}
+
+	allIssues, err := goconst.Run([]*ast.File{fProd, fTest}, fset, info, cfg)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	surviving := filterIssuesByPath(allIssues, []string{`_test\.go`})
+
+	// After filtering test issues, we should see the prod duplicate
+	// (ProdConst2 duplicates ProdConst1) but NOT a cross-scope duplicate.
+	var dupIssues []goconst.Issue
+	for _, issue := range surviving {
+		if issue.DuplicateConst != "" {
+			dupIssues = append(dupIssues, issue)
+		}
+	}
+
+	if len(dupIssues) != 1 {
+		t.Fatalf("expected 1 duplicate issue after filtering, got %d", len(dupIssues))
+	}
+
+	dup := dupIssues[0]
+	if dup.Pos.Filename != "consts.go" {
+		t.Errorf("duplicate issue in %s, want consts.go", dup.Pos.Filename)
+	}
+	if dup.DuplicateConst != "ProdConst1" && dup.DuplicateConst != "ProdConst2" {
+		t.Errorf("DuplicateConst = %q, want ProdConst1 or ProdConst2", dup.DuplicateConst)
+	}
+}
+
+func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
+	cfg := &types.Config{
+		Error: func(err error) {},
+	}
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+	}
+	return types.NewChecker(cfg, fset, types.NewPackage("", "example"), info), info
 }


### PR DESCRIPTION
Replaces fake contract tests with real pipeline tests that simulate how golangci-lint actually calls goconst.

## What changed

**Deleted:**
- `TestGolangCICompatibility` — constructed a struct literal and read fields back; `go build` already verifies this
- `TestMultipleIgnorePatterns` — passed nil files and ignored the error

**Added (pipeline tests):**
- `TestGolangCILintPipeline_ExcludeTests` — the issue #57 scenario: passes all files, applies `_test\.go` exclusion, verifies no false positives survive
- `TestGolangCILintPipeline_ExcludeTests_MatchingConst` — verifies surviving production issues don't reference test-only constants
- `TestGolangCILintPipeline_NoExclusion` — both scopes reported with accurate per-scope counts
- `TestGolangCILintPipeline_FindDuplicates` — duplicate detection respects scope after path exclusion

**Renamed for clarity:**
- `TestGolangCIIntegration` → `TestGolangCILintConfig_ExcludeCallAndIgnore`
- `TestMultipleIgnorePatternsIntegration` → `TestGolangCILintConfig_IgnoreStrings`
- `TestConstExpressionCompatibility` → `TestGolangCILintConfig_ConstExpressions`

The key insight: the old tests stopped at "call `Run()` and check output". The new pipeline tests add the missing step — `filterIssuesByPath()` — which is where issue #57 manifested.