### PR TITLE
fix(api): use exact constant keys for duplicates

### DIFF
--- a/api.go
+++ b/api.go
@@ -281,21 +281,11 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 	if p.findDuplicates {
 		p.constMutex.RLock()
 
-		stringKeys = make([]string, 0, len(p.consts))
-
-		for str := range p.consts {
-			if len(p.consts[str]) > 1 {
-				stringKeys = append(stringKeys, str)
-			}
-		}
-
-		sort.Strings(stringKeys)
-
 		// Report an issue for every duplicated const within the same scope.
 		// Test and non-test constants are compared independently so that a
 		// test constant is never flagged as duplicate of a production one.
-		for _, str := range stringKeys {
-			allConsts := p.consts[str]
+		for _, group := range duplicateConstGroups(p.consts) {
+			allConsts := group.consts
 
 			var nonTestConsts, testConsts []ConstType
 			for _, cst := range allConsts {
@@ -311,7 +301,7 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 				for i := 1; i < len(scopeConsts); i++ {
 					issueBuffer = append(issueBuffer, Issue{
 						Pos:            scopeConsts[i].Position,
-						Str:            str,
+						Str:            group.displayValue,
 						DuplicateConst: scopeConsts[0].Name,
 						DuplicatePos:   scopeConsts[0].Position,
 					})
@@ -353,4 +343,42 @@ func sortConstants(consts []ConstType) {
 	sort.Slice(consts, func(i, j int) bool {
 		return lessPosition(consts[i].Position, consts[j].Position)
 	})
+}
+
+type duplicateConstGroup struct {
+	displayValue string
+	consts       []ConstType
+}
+
+func duplicateConstGroups(consts Constants) []duplicateConstGroup {
+	groups := make(map[string]duplicateConstGroup, len(consts))
+	for displayValue, values := range consts {
+		for _, cst := range values {
+			key := cst.ValueKey()
+			if key == "" {
+				key = displayValue
+			}
+
+			group := groups[key]
+			if group.displayValue == "" || displayValue < group.displayValue {
+				group.displayValue = displayValue
+			}
+			group.consts = append(group.consts, cst)
+			groups[key] = group
+		}
+	}
+
+	keys := make([]string, 0, len(groups))
+	for key, group := range groups {
+		if len(group.consts) > 1 {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	result := make([]duplicateConstGroup, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, groups[key])
+	}
+	return result
 }

--- a/api_test.go
+++ b/api_test.go
@@ -71,6 +71,17 @@ func example() {
 			expectedIssues: 1,
 		},
 		{
+			name: "distinct long computed consts are not duplicates",
+			code: `package example
+const Foo = "this-is-a-non-duplicate-long-string-constant-with-a-distinctive-suffix-foo"
+const Bar = "this-is-a-non-duplicate-long-string-constant-with-a-distinctive-suffix-bar"`,
+			config: &Config{
+				FindDuplicates:       true,
+				EvalConstExpressions: true,
+			},
+			expectedIssues: 0,
+		},
+		{
 			name: "string duplication with ignore",
 			code: `package example
 func example() {
@@ -583,6 +594,7 @@ const (
 	Prefix = "example.com/"
 	Label1 = Prefix + "some_label"
 	Label2 = Prefix + "another_label"
+	LongLabel = "this-is-a-non-duplicate-long-string-constant-with-a-distinctive-suffix-foo"
 )
 
 func example() {
@@ -593,6 +605,9 @@ func example() {
 	// This should also match
 	web1 := "example.com/another_label"
 	web2 := "example.com/another_label"
+
+	long1 := "this-is-a-non-duplicate-long-string-constant-with-a-distinctive-suffix-foo"
+	long2 := "this-is-a-non-duplicate-long-string-constant-with-a-distinctive-suffix-foo"
 }
 `
 	fset := token.NewFileSet()
@@ -619,11 +634,12 @@ func example() {
 	expectedMatches := map[string]string{
 		"example.com/some_label":    "Label1",
 		"example.com/another_label": "Label2",
+		"this-is-a-non-duplicate-long-string-constant-with-a-distinctive-suffix-foo": "LongLabel",
 	}
 
-	// Check that we have two issues
-	if len(issues) != 2 {
-		t.Errorf("Expected 2 issues, got %d", len(issues))
+	// Check that we have one issue for each repeated string.
+	if len(issues) != len(expectedMatches) {
+		t.Errorf("Expected %d issues, got %d", len(expectedMatches), len(issues))
 		for _, issue := range issues {
 			t.Logf("Found issue: %q matches constant %q with %d occurrences",
 				issue.Str, issue.MatchingConst, issue.OccurrencesCount)
@@ -642,6 +658,117 @@ func example() {
 		if issue.MatchingConst != expectedConst {
 			t.Errorf("For string %q: got matching const %q, want %q",
 				issue.Str, issue.MatchingConst, expectedConst)
+		}
+	}
+}
+
+func TestConstExpressionsNumericConstantsUseLiteralFormat(t *testing.T) {
+	code := `package example
+
+const Half = 0.5
+
+func example() {
+	a := 0.5
+	b := 0.5
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse test code: %v", err)
+	}
+
+	config := &Config{
+		MinStringLength:      1,
+		MinOccurrences:       2,
+		MatchWithConstants:   true,
+		EvalConstExpressions: true,
+		ParseNumbers:         true,
+	}
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, config)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d: %#v", len(issues), issues)
+	}
+
+	if issues[0].Str != "0.5" {
+		t.Errorf("Str = %q, want 0.5", issues[0].Str)
+	}
+	if issues[0].MatchingConst != "Half" {
+		t.Errorf("MatchingConst = %q, want Half", issues[0].MatchingConst)
+	}
+}
+
+func TestFindDuplicatesWithImplicitConstValues(t *testing.T) {
+	code := `package example
+const (
+	ImplicitA = "implicit-value"
+	ImplicitB
+)
+const Explicit = "implicit-value"
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse test code: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, &Config{
+		FindDuplicates:       true,
+		EvalConstExpressions: true,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	duplicateNames := map[string]bool{}
+	for _, issue := range issues {
+		if issue.DuplicateConst != "" {
+			duplicateNames[issue.Pos.String()] = true
+		}
+	}
+
+	if len(duplicateNames) != 2 {
+		t.Fatalf("expected 2 duplicate issues for implicit and explicit duplicates, got %d: %#v", len(duplicateNames), issues)
+	}
+}
+
+func TestFindDuplicatesWithHighPrecisionNumericConstants(t *testing.T) {
+	code := `package example
+const Foo = 0.123456789012345678901234567890123456789
+const Bar = 0.123456789012345678901234567890123456788
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse test code: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	issues, err := Run([]*ast.File{f}, fset, info, &Config{
+		FindDuplicates:       true,
+		EvalConstExpressions: true,
+		ParseNumbers:         true,
+		MinStringLength:      1,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for _, issue := range issues {
+		if issue.DuplicateConst != "" {
+			t.Fatalf("unexpected duplicate issue for distinct high precision constants: %#v", issue)
 		}
 	}
 }
@@ -1574,6 +1701,7 @@ func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
 	}
 	info := &types.Info{
 		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
 	}
 	return types.NewChecker(cfg, fset, types.NewPackage("", "example"), info), info
 }

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/jgautheron/goconst"
@@ -240,12 +241,12 @@ func printOutput(strs goconst.Strings, consts goconst.Constants, output string) 
 				fmt.Printf("\n\t%s\n", csts[0].String())
 			}
 		}
-		for val, csts := range consts {
-			if len(csts) > 1 {
-				fmt.Printf("Duplicate constant(s) with value %q have been found:\n", val)
+		for _, group := range duplicateConstGroups(consts) {
+			if len(group.consts) > 1 {
+				fmt.Printf("Duplicate constant(s) with value %q have been found:\n", group.displayValue)
 
-				for i := 0; i < len(csts); i++ {
-					fmt.Printf("\t%s: %s\n", csts[i].String(), csts[i].Name)
+				for i := 0; i < len(group.consts); i++ {
+					fmt.Printf("\t%s: %s\n", group.consts[i].String(), group.consts[i].Name)
 				}
 			}
 		}
@@ -253,6 +254,44 @@ func printOutput(strs goconst.Strings, consts goconst.Constants, output string) 
 		return false, fmt.Errorf("unsupported output format: %s", output)
 	}
 	return len(strs)+len(consts) > 0, nil
+}
+
+type duplicateConstGroup struct {
+	displayValue string
+	consts       []goconst.ConstType
+}
+
+func duplicateConstGroups(consts goconst.Constants) []duplicateConstGroup {
+	groups := make(map[string]duplicateConstGroup, len(consts))
+	for displayValue, values := range consts {
+		for _, cst := range values {
+			key := cst.ValueKey()
+			if key == "" {
+				key = displayValue
+			}
+
+			group := groups[key]
+			if group.displayValue == "" || displayValue < group.displayValue {
+				group.displayValue = displayValue
+			}
+			group.consts = append(group.consts, cst)
+			groups[key] = group
+		}
+	}
+
+	keys := make([]string, 0, len(groups))
+	for key, group := range groups {
+		if len(group.consts) > 1 {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	result := make([]duplicateConstGroup, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, groups[key])
+	}
+	return result
 }
 
 // occurrences formats a list of all occurrences of a string, excluding the current position.

--- a/compat/compat_test.go
+++ b/compat/compat_test.go
@@ -357,6 +357,7 @@ func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
 	}
 	info := &types.Info{
 		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
 	}
 	return types.NewChecker(cfg, fset, types.NewPackage("", "example"), info), info
 }

--- a/parser.go
+++ b/parser.go
@@ -327,6 +327,7 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 		// run type checker
 		info := &types.Info{
 			Types: make(map[ast.Expr]types.TypeAndValue),
+			Defs:  make(map[*ast.Ident]types.Object),
 		}
 
 		chkConfig := &types.Config{
@@ -438,6 +439,7 @@ func (p *Parser) parseTreeConcurrent(rootPath string, recursive bool) (Strings, 
 	// Type checking must be performed serially to avoid data races.
 	info := &types.Info{
 		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
 	}
 
 	chkConfig := &types.Config{
@@ -684,6 +686,7 @@ func (p *Parser) parseTreeBatched(rootPath string, recursive bool) (Strings, Con
 		// Type check -- must be processed serially to avoid data races
 		info := &types.Info{
 			Types: make(map[ast.Expr]types.TypeAndValue),
+			Defs:  make(map[*ast.Ident]types.Object),
 		}
 
 		chkConfig := &types.Config{
@@ -874,6 +877,13 @@ type ConstType struct {
 	// Interned strings to reduce memory usage
 	Name        string
 	packageName string
+	valueKey    string
+}
+
+// ValueKey returns the internal comparison key used to distinguish constants
+// whose display values may be approximate, such as high-precision numbers.
+func (c ConstType) ValueKey() string {
+	return c.valueKey
 }
 
 // ExtendedPos extends token.Position with package information.

--- a/visitor.go
+++ b/visitor.go
@@ -43,21 +43,42 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 
 		for _, spec := range t.Specs {
 			val := spec.(*ast.ValueSpec)
+			if v.typeInfo != nil && v.p.evalConstExpressions {
+				if len(v.typeInfo.Defs) > 0 {
+					addedFromDefs := false
+					for _, name := range val.Names {
+						obj, ok := v.typeInfo.Defs[name].(*types.Const)
+						if !ok || obj.Val() == nil || !v.isSupportedKind(obj.Val().Kind()) {
+							continue
+						}
+
+						displayValue, valueKey := constValueStrings(obj.Val())
+						v.addConst(name.Name, displayValue, name.Pos(), valueKey)
+						addedFromDefs = true
+					}
+					if addedFromDefs || len(val.Values) == 0 {
+						continue
+					}
+				}
+			}
+
 			for i, str := range val.Values {
 				if v.typeInfo != nil && v.p.evalConstExpressions {
 					typedVal, ok := v.typeInfo.Types[str]
-					if !ok || !v.isSupportedKind(typedVal.Value.Kind()) {
+					if !ok || typedVal.Value == nil || !v.isSupportedKind(typedVal.Value.Kind()) {
 						continue
 					}
 
-					v.addConst(val.Names[i].Name, typedVal.Value.String(), str.Pos())
-				} else {
-					lit, ok := str.(*ast.BasicLit)
-					if !ok || !v.isSupported(lit.Kind) {
-						continue
-					}
-					v.addConst(val.Names[i].Name, lit.Value, val.Names[i].Pos())
+					displayValue, valueKey := constValueStrings(typedVal.Value)
+					v.addConst(val.Names[i].Name, displayValue, str.Pos(), valueKey)
+					continue
 				}
+
+				lit, ok := str.(*ast.BasicLit)
+				if !ok || !v.isSupported(lit.Kind) {
+					continue
+				}
+				v.addConst(val.Names[i].Name, lit.Value, val.Names[i].Pos())
 			}
 		}
 
@@ -128,6 +149,13 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 	}
 
 	return v
+}
+
+func constValueStrings(val constant.Value) (string, string) {
+	if val.Kind() == constant.String {
+		return val.ExactString(), "string:" + constant.StringVal(val)
+	}
+	return val.String(), val.Kind().String() + ":" + val.ExactString()
 }
 
 func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr) {
@@ -245,7 +273,7 @@ func (v *treeVisitor) addString(str string, pos token.Pos, typ Type) {
 }
 
 // addConst adds a const in the map along with its position in the tree.
-func (v *treeVisitor) addConst(name string, val string, pos token.Pos) {
+func (v *treeVisitor) addConst(name string, val string, pos token.Pos, valueKey ...string) {
 	// Early filtering using the same criteria as for strings
 	var unquotedVal string
 	if strings.HasPrefix(val, `"`) || strings.HasPrefix(val, "`") {
@@ -280,6 +308,10 @@ func (v *treeVisitor) addConst(name string, val string, pos token.Pos) {
 	internedVal := InternString(unquotedVal)
 	internedName := InternString(name)
 	internedPkg := InternString(v.packageName)
+	internedKey := internedVal
+	if len(valueKey) > 0 && valueKey[0] != "" {
+		internedKey = InternString(valueKey[0])
+	}
 
 	// Lock to safely update the shared map
 	v.p.constMutex.Lock()
@@ -292,6 +324,7 @@ func (v *treeVisitor) addConst(name string, val string, pos token.Pos) {
 		v.p.consts[internedVal] = append(v.p.consts[internedVal], ConstType{
 			Name:        internedName,
 			packageName: internedPkg,
+			valueKey:    internedKey,
 			Position:    v.fileSet.Position(pos),
 		})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate constant detection and reporting to accurately identify duplicates while reducing false positives for constants with distinct values or expressions.
  * Added deterministic ordering to duplicate constant reports for consistent output.

* **Tests**
  * Expanded test coverage for computed constant deduplication scenarios, including numeric precision and implicit constant values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jgautheron/goconst/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->