### PR TITLE
✨ add ignore-map-keys option to skip string map keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Flags:
   -eval-const-expr            enable evaluation of constant expressions (e.g., Prefix + "suffix")
   -ignore-calls               ignore string literals in calls to these functions (comma separated)
   -ignore-composite-literals  ignore string literals inside composite literals
+  -ignore-map-keys            ignore string literals used as map keys
   -numbers                    search also for duplicated numbers
   -min                        minimum value, only works with -numbers
   -max                        maximum value, only works with -numbers

--- a/api.go
+++ b/api.go
@@ -50,6 +50,9 @@ type Config struct {
 	// IgnoreFunctions is a list of function names whose string arguments should be ignored.
 	// Supports direct calls (e.g., "println") and one-level qualified calls (e.g., "slog.Info").
 	IgnoreFunctions []string
+	// IgnoreMapKeys ignores string literals used as keys in map literals
+	// (e.g., the "key" in map[string]any{"key": "value"}).
+	IgnoreMapKeys bool
 }
 
 // NewWithIgnorePatterns creates a new instance of the parser with support for multiple ignore patterns.
@@ -115,6 +118,10 @@ func RunWithConfig(files []*ast.File, fset *token.FileSet, typeInfo *types.Info,
 
 	if len(cfg.IgnoreFunctions) > 0 {
 		p.SetIgnoreFunctions(cfg.IgnoreFunctions)
+	}
+
+	if cfg.IgnoreMapKeys {
+		p.SetIgnoreMapKeys(true)
 	}
 
 	// Pre-allocate slice based on estimated result size

--- a/cmd/goconst/main.go
+++ b/cmd/goconst/main.go
@@ -31,6 +31,7 @@ Flags:
   -eval-const-expr            enable evaluation of constant expressions (e.g., Prefix + "suffix")
   -ignore-calls               ignore string literals in calls to these functions (comma separated)
   -ignore-composite-literals  ignore string literals inside composite literals
+  -ignore-map-keys            ignore string literals used as map keys
   -numbers                    search also for duplicated numbers
   -min                        minimum value, only works with -numbers
   -max                        maximum value, only works with -numbers
@@ -66,6 +67,7 @@ var (
 	flagGrouped                 = flag.Bool("grouped", false, "print single line per match, only works with -output text")
 	flagIgnoreCalls             = flag.String("ignore-calls", "", "ignore string literals in calls to these functions (comma separated, e.g. slog.Info,fmt.Errorf)")
 	flagIgnoreCompositeLiterals = flag.Bool("ignore-composite-literals", false, "ignore string literals inside composite literals")
+	flagIgnoreMapKeys           = flag.Bool("ignore-map-keys", false, "ignore string literals used as map keys")
 )
 
 func main() {
@@ -129,6 +131,8 @@ func run(path string) (bool, error) {
 	if *flagIgnoreCalls != "" {
 		gco.SetIgnoreFunctions(parseCommaSeparatedValues(*flagIgnoreCalls))
 	}
+
+	gco.SetIgnoreMapKeys(*flagIgnoreMapKeys)
 
 	strs, consts, err := gco.ParseTree()
 	if err != nil {

--- a/compat/compat_test.go
+++ b/compat/compat_test.go
@@ -351,6 +351,105 @@ func example() {
 	}
 }
 
+// TestGolangCILintConfig_IgnoreMapKeys exercises the IgnoreMapKeys config field
+// through the Run entrypoint golangci-lint uses. Map keys are dropped while
+// repeated map values are still reported.
+func TestGolangCILintConfig_IgnoreMapKeys(t *testing.T) {
+	code := `package example
+func example() {
+	_ = map[string]string{"key": "shared"}
+	_ = map[string]string{"key": "shared"}
+}
+`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	// With IgnoreMapKeys: the repeated key is dropped, the value survives.
+	cfg := &goconst.Config{
+		MinStringLength: 1,
+		MinOccurrences:  2,
+		IgnoreMapKeys:   true,
+	}
+	issues, err := goconst.Run([]*ast.File{f}, fset, info, cfg)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	found := make(map[string]bool)
+	for _, issue := range issues {
+		found[issue.Str] = true
+	}
+	if found["key"] {
+		t.Error("unexpected issue for map key 'key' (filtered by IgnoreMapKeys)")
+	}
+	if !found["shared"] {
+		t.Error("expected issue for repeated map value 'shared'")
+	}
+
+	// Without IgnoreMapKeys: the repeated key is reported as before.
+	cfgOff := &goconst.Config{MinStringLength: 1, MinOccurrences: 2}
+	issuesOff, err := goconst.Run([]*ast.File{f}, fset, info, cfgOff)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	foundOff := make(map[string]bool)
+	for _, issue := range issuesOff {
+		foundOff[issue.Str] = true
+	}
+	if !foundOff["key"] {
+		t.Error("expected issue for map key 'key' when IgnoreMapKeys is disabled")
+	}
+}
+
+// TestGolangCILintConfig_IgnoreMapKeys_ExpressionKeys covers keys that are
+// expressions rather than plain literals in a named map type. Recognizing the
+// named map requires the type information golangci-lint supplies.
+func TestGolangCILintConfig_IgnoreMapKeys_ExpressionKeys(t *testing.T) {
+	code := `package example
+type K string
+type M map[K]string
+func example() {
+	_ = M{K("role"): "shared"}
+	_ = M{K("role"): "shared"}
+}
+`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", code, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	chkr, info := checker(fset)
+	_ = chkr.Files([]*ast.File{f})
+
+	cfg := &goconst.Config{
+		MinStringLength: 1,
+		MinOccurrences:  2,
+		IgnoreMapKeys:   true,
+	}
+	issues, err := goconst.Run([]*ast.File{f}, fset, info, cfg)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	found := make(map[string]bool)
+	for _, issue := range issues {
+		found[issue.Str] = true
+	}
+	if found["role"] {
+		t.Error("unexpected issue for converted map key 'role' (filtered by IgnoreMapKeys)")
+	}
+	if !found["shared"] {
+		t.Error("expected issue for repeated map value 'shared'")
+	}
+}
+
 func checker(fset *token.FileSet) (*types.Checker, *types.Info) {
 	cfg := &types.Config{
 		Error: func(err error) {},

--- a/parser.go
+++ b/parser.go
@@ -121,6 +121,7 @@ type Parser struct {
 	numberMin, numberMax        int
 	excludeTypes                map[Type]bool
 	ignoreFunctions             map[string]struct{}
+	ignoreMapKeys               bool // Whether to ignore string literals used as map keys
 	maxConcurrency              int
 	evalConstExpressions        bool // Whether to evaluate constant expressions
 
@@ -281,6 +282,12 @@ func (p *Parser) SetIgnoreFunctions(names []string) {
 		}
 	}
 	p.ignoreFunctions = m
+}
+
+// SetIgnoreMapKeys configures whether string literals used as keys in map
+// literals should be ignored. The corresponding values are still reported.
+func (p *Parser) SetIgnoreMapKeys(ignore bool) {
+	p.ignoreMapKeys = ignore
 }
 
 // ParseTree will search the given path for occurrences that could be moved into constants.

--- a/visitor.go
+++ b/visitor.go
@@ -207,7 +207,7 @@ func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr, isMap bool) {
 		// keys are identifiers, array indices are integers), so it is dropped
 		// when requested with no type information; numeric keys are out of
 		// scope and kept.
-		if v.isSupported(keyLit.Kind) && !(v.p.ignoreMapKeys && keyLit.Kind == token.STRING) {
+		if v.isSupported(keyLit.Kind) && (!v.p.ignoreMapKeys || keyLit.Kind != token.STRING) {
 			v.addString(keyLit.Value, keyLit.Pos(), CompositeLit)
 		}
 	} else if v.p.ignoreMapKeys && isMap {

--- a/visitor.go
+++ b/visitor.go
@@ -18,6 +18,12 @@ type treeVisitor struct {
 	packageName string
 	p           *Parser
 	ignoreRegex *regexp.Regexp
+
+	// skipNodes holds map-key expression subtrees to skip entirely while
+	// walking, used by -ignore-map-keys for keys that are not plain literals
+	// (e.g. NamedString("key")). Populated per file; the walk is single
+	// threaded so no synchronization is needed.
+	skipNodes map[ast.Node]struct{}
 }
 
 // Visit browses the AST tree for strings that could be potentially
@@ -26,6 +32,12 @@ type treeVisitor struct {
 func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 	if node == nil {
 		return v
+	}
+
+	// Prune map-key expression subtrees flagged by -ignore-map-keys so their
+	// string literals are never recorded (e.g. the "key" in K("key")).
+	if _, skip := v.skipNodes[node]; skip {
+		return nil
 	}
 
 	// A single case with "ast.BasicLit" would be much easier
@@ -143,8 +155,14 @@ func (v *treeVisitor) Visit(node ast.Node) ast.Visitor {
 
 	// []string{"foo"}, map[string]string{"k": "v"}, struct{A string}{A: "foo"}
 	case *ast.CompositeLit:
+		// isMap is only consulted for pruning expression keys, which matters
+		// only when -ignore-map-keys is set.
+		isMap := false
+		if v.p.ignoreMapKeys {
+			isMap = v.isMapLiteral(t)
+		}
 		for _, item := range t.Elts {
-			v.addCompositeLiteralElement(item)
+			v.addCompositeLiteralElement(item, isMap)
 		}
 	}
 
@@ -158,7 +176,22 @@ func constValueStrings(val constant.Value) (string, string) {
 	return val.String(), val.Kind().String() + ":" + val.ExactString()
 }
 
-func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr) {
+// isMapLiteral reports whether a composite literal is a map. It prefers type
+// information (which resolves named map types and elided nested literals) and
+// falls back to the syntactic type when none is available (e.g. the CLI path,
+// where only explicit map[...]... literals can be recognized).
+func (v *treeVisitor) isMapLiteral(t *ast.CompositeLit) bool {
+	if v.typeInfo != nil {
+		if tv, ok := v.typeInfo.Types[t]; ok && tv.Type != nil {
+			_, isMap := tv.Type.Underlying().(*types.Map)
+			return isMap
+		}
+	}
+	_, ok := t.Type.(*ast.MapType)
+	return ok
+}
+
+func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr, isMap bool) {
 	if lit, ok := node.(*ast.BasicLit); ok && v.isSupported(lit.Kind) {
 		v.addString(lit.Value, lit.Pos(), CompositeLit)
 		return
@@ -169,13 +202,32 @@ func (v *treeVisitor) addCompositeLiteralElement(node ast.Expr) {
 		return
 	}
 
-	if keyLit, ok := kv.Key.(*ast.BasicLit); ok && v.isSupported(keyLit.Kind) {
-		v.addString(keyLit.Value, keyLit.Pos(), CompositeLit)
+	if keyLit, ok := kv.Key.(*ast.BasicLit); ok {
+		// Direct literal key. A string literal can only be a map key (struct
+		// keys are identifiers, array indices are integers), so it is dropped
+		// when requested with no type information; numeric keys are out of
+		// scope and kept.
+		if v.isSupported(keyLit.Kind) && !(v.p.ignoreMapKeys && keyLit.Kind == token.STRING) {
+			v.addString(keyLit.Value, keyLit.Pos(), CompositeLit)
+		}
+	} else if v.p.ignoreMapKeys && isMap {
+		// Key is an expression (e.g. NamedString("key")); any string literal it
+		// contains is part of the map key, so skip the whole subtree. Gated on
+		// isMap so array indices such as [10]int{int(2): 1} are left alone.
+		v.markSkip(kv.Key)
 	}
 
 	if valueLit, ok := kv.Value.(*ast.BasicLit); ok && v.isSupported(valueLit.Kind) {
 		v.addString(valueLit.Value, valueLit.Pos(), CompositeLit)
 	}
+}
+
+// markSkip flags an AST node so the walk prunes it and its subtree.
+func (v *treeVisitor) markSkip(node ast.Node) {
+	if v.skipNodes == nil {
+		v.skipNodes = make(map[ast.Node]struct{})
+	}
+	v.skipNodes[node] = struct{}{}
 }
 
 // shouldIgnoreCall returns true if the call expression matches a function

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -15,6 +15,8 @@ func TestTreeVisitor_Visit(t *testing.T) {
 		expectedStrings     []string
 		expectedConstCounts map[string]int
 		excludeTypes        map[Type]bool
+		ignoreMapKeys       bool
+		supportedTokens     []token.Token // defaults to STRING only when nil
 	}{
 		{
 			name: "assignment detection",
@@ -150,6 +152,169 @@ func example() {
 			expectedConstCounts: map[string]int{},
 			excludeTypes:        map[Type]bool{},
 		},
+		{
+			name: "map keys ignored, values kept",
+			code: `package example
+func example() {
+	_ = map[string]string{"key": "value1"}
+	_ = map[string]string{"key": "value2"}
+}`,
+			expectedStrings:     []string{"value1", "value2"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			name: "map keys kept when not ignored",
+			code: `package example
+func example() {
+	_ = map[string]string{"key": "value1"}
+}`,
+			expectedStrings:     []string{"key", "value1"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+		},
+		{
+			name: "ignore-map-keys leaves slice and struct literals untouched",
+			code: `package example
+type person struct {
+	name string
+}
+
+func example() {
+	_ = []string{"aaa"}
+	_ = person{name: "bbb"}
+}`,
+			expectedStrings:     []string{"aaa", "bbb"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			// Named map type: the literal's AST type is an *ast.Ident, so this
+			// relies on string keys being recognized without type information.
+			name: "map keys ignored for named map type without type info",
+			code: `package example
+type M map[string]string
+func example() {
+	_ = M{"key": "value1"}
+	_ = M{"key": "value2"}
+}`,
+			expectedStrings:     []string{"value1", "value2"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			// Nested elided map literals have a nil AST type; string keys must
+			// still be ignored without type information.
+			name: "map keys ignored for elided nested map literals",
+			code: `package example
+func example() {
+	_ = []map[string]string{
+		{"key": "value1"},
+		{"key": "value2"},
+	}
+}`,
+			expectedStrings:     []string{"value1", "value2"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			// The skip targets the KeyValueExpr key node, not the string value:
+			// the same literal used elsewhere (here as an assignment) is kept.
+			name: "map key skip is per-occurrence, not a global blacklist",
+			code: `package example
+func example() {
+	_ = map[string]string{"dup": "value"}
+	a := "dup"
+	_ = a
+}`,
+			expectedStrings:     []string{"dup", "value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			// IgnoreMapKeys is scoped to string keys by design; numeric keys are
+			// left in place (they are indistinguishable from array indices
+			// without type information).
+			name: "numeric map keys still reported (string-only scope)",
+			code: `package example
+func example() {
+	_ = map[int]string{100: "value"}
+}`,
+			expectedStrings:     []string{"100", "value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+			supportedTokens:     []token.Token{token.STRING, token.INT},
+		},
+		{
+			// A raw (backtick) string key is also token.STRING and must be ignored.
+			name: "raw string map keys are ignored too",
+			code: "package example\n" +
+				"func example() {\n" +
+				"\t_ = map[string]string{`rawkey`: \"value1\"}\n" +
+				"\t_ = map[string]string{`rawkey`: \"value2\"}\n" +
+				"}",
+			expectedStrings:     []string{"value1", "value2"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			// Key wrapped in a builtin conversion: the string subtree must be
+			// pruned so the later CallExpr visit does not record it.
+			name: "converted string map keys are ignored",
+			code: `package example
+func example() {
+	_ = map[string]string{string("key"): "value"}
+}`,
+			expectedStrings:     []string{"value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			// Named-string-typed key via conversion (map[K]V{K("role"): ...}).
+			name: "converted named-string map keys are ignored",
+			code: `package example
+type K string
+func example() {
+	_ = map[K]string{K("role"): "value"}
+}`,
+			expectedStrings:     []string{"value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+		},
+		{
+			name: "converted map keys kept when not ignored",
+			code: `package example
+type K string
+func example() {
+	_ = map[K]string{K("role"): "value"}
+}`,
+			expectedStrings:     []string{"role", "value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+		},
+		{
+			// Array index expressions are not map keys; their literals must
+			// survive even with ignore-map-keys enabled (isMap gate).
+			name: "numeric array index expressions are not suppressed",
+			code: `package example
+func example() {
+	_ = [500]string{int(100): "value"}
+}`,
+			expectedStrings:     []string{"100", "value"},
+			expectedConstCounts: map[string]int{},
+			excludeTypes:        map[Type]bool{},
+			ignoreMapKeys:       true,
+			supportedTokens:     []token.Token{token.STRING, token.INT},
+		},
 	}
 
 	for _, tt := range tests {
@@ -160,11 +325,17 @@ func example() {
 				t.Fatalf("Failed to parse test code: %v", err)
 			}
 
+			supportedTokens := tt.supportedTokens
+			if supportedTokens == nil {
+				supportedTokens = []token.Token{token.STRING}
+			}
+
 			p := &Parser{
 				minLength:        3,
 				minOccurrences:   1,
-				supportedTokens:  []token.Token{token.STRING},
+				supportedTokens:  supportedTokens,
 				excludeTypes:     tt.excludeTypes,
+				ignoreMapKeys:    tt.ignoreMapKeys,
 				strs:             Strings{},
 				consts:           Constants{},
 				matchConstant:    true,


### PR DESCRIPTION
Implements #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `-ignore-map-keys` CLI option to exclude string literals used as map keys from analysis.
  - Added configuration support for enabling this behavior programmatically.
  - Map values and string literals outside map keys continue to be reported normally.

- **Documentation**
  - Updated usage documentation with the new CLI option.

- **Tests**
  - Added coverage for direct, converted, nested, and typed map keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->